### PR TITLE
Prefix backend API endpoints URL with '/kachna/api'

### DIFF
--- a/ClientApp/KachnaOnline/src/app/users/user-logged-in.guard.ts
+++ b/ClientApp/KachnaOnline/src/app/users/user-logged-in.guard.ts
@@ -4,7 +4,7 @@
 import { Injectable } from '@angular/core';
 import { ActivatedRouteSnapshot, CanActivate, Router, RouterStateSnapshot, UrlTree } from '@angular/router';
 import { Observable } from 'rxjs';
-import { AuthenticationService } from "../../shared/services/authentication.service";
+import { AuthenticationService } from "../shared/services/authentication.service";
 
 @Injectable({
   providedIn: 'root'

--- a/ClientApp/KachnaOnline/src/app/users/users-routing.module.ts
+++ b/ClientApp/KachnaOnline/src/app/users/users-routing.module.ts
@@ -6,7 +6,7 @@ import { RouterModule, Routes } from '@angular/router';
 
 import { LoginComponent } from './login/login.component';
 import { UserProfileComponent } from "./user-profile/user-profile.component";
-import { UserLoggedInGuard } from "./user-profile/user-logged-in.guard";
+import { UserLoggedInGuard } from "./user-logged-in.guard";
 import { UsersListComponent } from "./users-list/users-list.component";
 import { AdminGuard } from "./admin.guard";
 

--- a/ClientApp/KachnaOnline/src/environments/environment.prod.ts
+++ b/ClientApp/KachnaOnline/src/environments/environment.prod.ts
@@ -8,7 +8,7 @@ import { IEnvironment, IEnvironmentParams } from "./ienvironment";
  */
 const params: IEnvironmentParams = {
   production: true,
-  baseApiUrl: '/api', // FIXME: Add real URL.
+  baseApiUrl: 'kachna/api', // FIXME: Add real URL.
   baseApiUrlDomain: 'localhost:5000', // FIXME: Add real URL.
 };
 

--- a/ClientApp/KachnaOnline/src/environments/environment.ts
+++ b/ClientApp/KachnaOnline/src/environments/environment.ts
@@ -12,7 +12,7 @@ import { IEnvironment, IEnvironmentParams } from "./ienvironment";
  */
 const params: IEnvironmentParams = {
   production: false,
-  baseApiUrl: 'http://localhost:5000',
+  baseApiUrl: 'http://localhost:5000/kachna/api',
   baseApiUrlDomain: 'localhost:5000',
 };
 

--- a/ClientApp/KachnaOnline/src/environments/ienvironment.ts
+++ b/ClientApp/KachnaOnline/src/environments/ienvironment.ts
@@ -7,7 +7,7 @@
 export class IEnvironment implements IEnvironmentParams {
   // Modifiable by the current environment.
   public production: boolean = false;
-  public baseApiUrl: string = 'http://localhost:5000';
+  public baseApiUrl: string = 'http://localhost:5000/kachna/api';
   public baseApiUrlDomain: string = 'localhost:5000';
 
   // Global constants.


### PR DESCRIPTION
This PR prefixes the Kachna Online API URL for the frontend methods with `/kachna/api`. Also moves user logged in guard one level up to general users space to be used by other modules.