### PR TITLE
Implement linking planned states to events

### DIFF
--- a/KachnaOnline.App/Controllers/ClubStateController.cs
+++ b/KachnaOnline.App/Controllers/ClubStateController.cs
@@ -328,5 +328,37 @@ namespace KachnaOnline.App.Controllers
                 return this.ForbiddenProblem("Only administrators may change a state's made by ID.");
             }
         }
+
+        /// <summary>
+        /// Unlinks the specified linked state from any event.
+        /// </summary>
+        /// <param name="stateId">ID of the planned state to be unlinked from any event.</param>
+        /// <response code="204">The planned states was unlinked from the event.</response>
+        /// <response code="404">The state with the given ID <paramref name="stateId"/> does not exist.</response>
+        /// <response code="409">The state that has already started or ended cannot be modified.</response>
+        [HttpDelete("{stateId}/linkedEvent")]
+        [ProducesResponseType(StatusCodes.Status204NoContent)]
+        [ProducesResponseType(StatusCodes.Status404NotFound)]
+        [ProducesResponseType(StatusCodes.Status409Conflict)]
+        public async Task<IActionResult> UnlinkStateFromEvent(int stateId)
+        {
+            try
+            {
+                await _facade.UnlinkStateFromEvent(stateId);
+                return this.NoContent();
+            }
+            catch (StateReadOnlyException)
+            {
+                return this.ConflictProblem("The specified state cannot be modified because it has already started or ended.");
+            }
+            catch (StateNotAssociatedToEventException)
+            {
+                return this.ConflictProblem("The specified state is not linked to any event.");
+            }
+            catch (StateNotFoundException)
+            {
+                return this.NotFoundProblem("The specified state does not exist.");
+            }
+        }
     }
 }

--- a/KachnaOnline.Business.Data/Repositories/Abstractions/IEventsRepository.cs
+++ b/KachnaOnline.Business.Data/Repositories/Abstractions/IEventsRepository.cs
@@ -13,6 +13,5 @@ namespace KachnaOnline.Business.Data.Repositories.Abstractions
         IAsyncEnumerable<Event> GetCurrent(DateTime? at = null);
         IAsyncEnumerable<Event> GetNearest(DateTime? after = null);
         IAsyncEnumerable<Event> GetStartingBetween(DateTime from, DateTime to);
-        Task<Event> GetWithLinkedStates(int eventId);
     }
 }

--- a/KachnaOnline.Business.Data/Repositories/Abstractions/IEventsRepository.cs
+++ b/KachnaOnline.Business.Data/Repositories/Abstractions/IEventsRepository.cs
@@ -3,6 +3,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.Threading.Tasks;
 using KachnaOnline.Data.Entities.Events;
 
 namespace KachnaOnline.Business.Data.Repositories.Abstractions
@@ -12,5 +13,6 @@ namespace KachnaOnline.Business.Data.Repositories.Abstractions
         IAsyncEnumerable<Event> GetCurrent(DateTime? at = null);
         IAsyncEnumerable<Event> GetNearest(DateTime? after = null);
         IAsyncEnumerable<Event> GetStartingBetween(DateTime from, DateTime to);
+        Task<Event> GetWithLinkedStates(int eventId);
     }
 }

--- a/KachnaOnline.Business.Data/Repositories/Abstractions/IPlannedStatesRepository.cs
+++ b/KachnaOnline.Business.Data/Repositories/Abstractions/IPlannedStatesRepository.cs
@@ -16,10 +16,9 @@ namespace KachnaOnline.Business.Data.Repositories.Abstractions
         Task<PlannedState> GetLastEnded();
         Task<PlannedState> GetPreviousFor(int stateId);
         IAsyncEnumerable<PlannedState> GetStartingBetween(DateTime from, DateTime to, bool includeNextStates = false);
-
+        IAsyncEnumerable<PlannedState> GetConflictingStatesForEvent(DateTime from, DateTime to);
         IAsyncEnumerable<PlannedState> GetForRepeatingState(int repeatingStateId, DateTime? onlyAfter = null,
             bool includeNextStates = false);
-
         IAsyncEnumerable<PlannedState> GetPastNotEnded();
     }
 }

--- a/KachnaOnline.Business.Data/Repositories/EventsRepository.cs
+++ b/KachnaOnline.Business.Data/Repositories/EventsRepository.cs
@@ -50,10 +50,5 @@ namespace KachnaOnline.Business.Data.Repositories
                 .Where(e => e.From >= from && e.From <= to)
                 .AsAsyncEnumerable();
         }
-
-        public async Task<Event> GetWithLinkedStates(int eventId)
-        {
-            return await Set.Include(e => e.LinkedPlannedStates).FirstOrDefaultAsync(e => e.Id == eventId);
-        }
     }
 }

--- a/KachnaOnline.Business.Data/Repositories/EventsRepository.cs
+++ b/KachnaOnline.Business.Data/Repositories/EventsRepository.cs
@@ -4,6 +4,7 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using System.Threading.Tasks;
 using KachnaOnline.Business.Data.Repositories.Abstractions;
 using KachnaOnline.Data;
 using KachnaOnline.Data.Entities.Events;
@@ -15,6 +16,11 @@ namespace KachnaOnline.Business.Data.Repositories
     {
         public EventsRepository(AppDbContext dbContext) : base(dbContext)
         {
+        }
+
+        public override async Task<Event> Get(int key)
+        {
+            return await Set.Include(e => e.LinkedPlannedStates).FirstOrDefaultAsync(e => e.Id == key);
         }
 
         public IAsyncEnumerable<Event> GetCurrent(DateTime? atTime = null)
@@ -43,6 +49,11 @@ namespace KachnaOnline.Business.Data.Repositories
             return Set
                 .Where(e => e.From >= from && e.From <= to)
                 .AsAsyncEnumerable();
+        }
+
+        public async Task<Event> GetWithLinkedStates(int eventId)
+        {
+            return await Set.Include(e => e.LinkedPlannedStates).FirstOrDefaultAsync(e => e.Id == eventId);
         }
     }
 }

--- a/KachnaOnline.Business.Data/Repositories/PlannedStatesRepository.cs
+++ b/KachnaOnline.Business.Data/Repositories/PlannedStatesRepository.cs
@@ -97,6 +97,11 @@ namespace KachnaOnline.Business.Data.Repositories
             return query.AsAsyncEnumerable();
         }
 
+        public IAsyncEnumerable<PlannedState> GetConflictingStatesForEvent(DateTime from, DateTime to)
+        {
+            return Set.Where(s => s.Start >= from && s.PlannedEnd <= to).AsAsyncEnumerable();
+        }
+
         public IAsyncEnumerable<PlannedState> GetForRepeatingState(int repeatingStateId, DateTime? onlyAfter,
             bool includeNextStates)
         {

--- a/KachnaOnline.Business/Exceptions/ClubStates/RepeatingStateNotFoundException.cs
+++ b/KachnaOnline.Business/Exceptions/ClubStates/RepeatingStateNotFoundException.cs
@@ -1,4 +1,4 @@
-// StateNotFoundException.cs
+// RepeatingStateNotFoundException.cs
 // Author: Ondřej Ondryáš
 
 using System;

--- a/KachnaOnline.Business/Exceptions/ClubStates/StateNotAssociatedToEventException.cs
+++ b/KachnaOnline.Business/Exceptions/ClubStates/StateNotAssociatedToEventException.cs
@@ -1,0 +1,25 @@
+// StateNotAssociatedToEventException.cs
+// Author: David Chocholatý
+
+using System;
+
+namespace KachnaOnline.Business.Exceptions.ClubStates
+{
+    public class StateNotAssociatedToEventException : Exception
+    {
+        public int? StateId { get; }
+
+        public StateNotAssociatedToEventException() : base("The specified state is not associated to any event.")
+        {
+        }
+
+        public StateNotAssociatedToEventException(int stateId) : base($"State with ID {stateId} is not associated to any event.")
+        {
+            this.StateId = stateId;
+        }
+
+        public StateNotAssociatedToEventException(string message) : base(message)
+        {
+        }
+    }
+}

--- a/KachnaOnline.Business/Exceptions/Events/LinkingStateToEventException.cs
+++ b/KachnaOnline.Business/Exceptions/Events/LinkingStateToEventException.cs
@@ -1,0 +1,34 @@
+// LinkingStateToEventException.cs
+// Author: David Chocholatý
+
+using System;
+
+namespace KachnaOnline.Business.Exceptions.Events
+{
+    public class LinkingStateToEventException : Exception
+    {
+        public int? StateId { get; }
+        public int? EventId { get; }
+
+        public LinkingStateToEventException(string message) : base(message)
+        {
+        }
+
+        public LinkingStateToEventException(string message, int eventId, int stateId) : base(message)
+        {
+            this.StateId = stateId;
+            this.EventId = eventId;
+        }
+
+        public LinkingStateToEventException(string message, Exception innerException) : base(message, innerException)
+        {
+        }
+
+        public LinkingStateToEventException(string message, Exception innerException, int eventId, int stateId) : base(message,
+            innerException)
+        {
+            this.StateId = stateId;
+            this.EventId = eventId;
+        }
+    }
+}

--- a/KachnaOnline.Business/Facades/ClubStateFacade.cs
+++ b/KachnaOnline.Business/Facades/ClubStateFacade.cs
@@ -295,5 +295,17 @@ namespace KachnaOnline.Business.Facades
         {
             await _clubStateService.CloseNow(this.CurrentUserId);
         }
+
+        /// <summary>
+        /// Unlinks the specified linked state from any event.
+        /// </summary>
+        /// <param name="stateId">ID of the planned state to be unlinked from any event.</param>
+        /// <exception cref="StateReadOnlyException">Thrown when planned state to be unlinked from the event has already started or ended.</exception>
+        /// <exception cref="StateNotFoundException">Thrown when planned state to be unlinked from the event has not been found.</exception>
+        /// <exception cref="StateNotAssociatedToEventException">Thrown when planned states is not associated to any event.</exception>
+        public async Task UnlinkStateFromEvent(int stateId)
+        {
+            await _clubStateService.UnlinkStateFromEvent(stateId);
+        }
     }
 }

--- a/KachnaOnline.Business/Facades/EventsFacade.cs
+++ b/KachnaOnline.Business/Facades/EventsFacade.cs
@@ -8,6 +8,8 @@ using System.Security.Claims;
 using System.Threading.Tasks;
 using AutoMapper;
 using KachnaOnline.Business.Constants;
+using KachnaOnline.Business.Exceptions;
+using KachnaOnline.Business.Exceptions.ClubStates;
 using KachnaOnline.Business.Exceptions.Events;
 using KachnaOnline.Business.Models.ClubStates;
 using KachnaOnline.Business.Models.Events;
@@ -112,6 +114,7 @@ namespace KachnaOnline.Business.Facades
         /// <param name="from">If not null, only returns events with their from date being after or equal to the specified value.</param>
         /// <param name="to">If not null, only returns events with their to date being before or equal to the specified value.</param>
         /// <returns>A List of <see cref="KachnaOnline.Dto.Events.EventDto"/> or an empty list if no there is no event planned.</returns>
+        /// <exception cref="ArgumentException">Thrown when <paramref name="from"/> or <paramref name="to"/> are invalid.</exception>
         public async Task<IEnumerable<EventDto>> GetEvents(DateTime? from = null, DateTime? to = null)
         {
             var events = await _eventsService.GetEvents(from, to);
@@ -133,7 +136,7 @@ namespace KachnaOnline.Business.Facades
                 return this.MapEventWithLinkedStates(await _eventsService.GetEventWithLinkedStates(eventId));
             }
 
-            return this.MapEvent(await _eventsService.GetEventWithLinkedStates(eventId));
+            return this.MapEvent(await _eventsService.GetEvent(eventId));
         }
 
         /// <summary>
@@ -152,6 +155,12 @@ namespace KachnaOnline.Business.Facades
         /// </summary>
         /// <param name="newEvent">New event data to create the new event with.</param>
         /// <returns>Created event with its ID attribute filled.</returns>
+        /// <exception cref="ArgumentNullException">Thrown when <paramref name="newEvent"/> is null.</exception>
+        /// <exception cref="ArgumentException">Thrown when <paramref name="newEvent"/> has invalid attributes.</exception>
+        /// <exception cref="EventManipulationFailedException">Thrown when the board game cannot be created.
+        /// This can be caused by a database error.</exception>
+        /// <exception cref="UserNotFoundException">Thrown when a user with the ID assigned to the event does
+        /// not exist.</exception>
         public async Task<ManagerEventDto> PlanEvent(BaseEventDto newEvent)
         {
             var newEventModel = _mapper.Map<NewEvent>(newEvent);
@@ -166,7 +175,9 @@ namespace KachnaOnline.Business.Facades
         /// Get conflicting states for an event specified by <paramref name="eventId"/>.
         /// </summary>
         /// <param name="eventId">The event ID to get the conflicting states for.</param>
-        /// <returns></returns>
+        /// <returns>An enumerable of <see cref="StateDto"/> of conflicting states.</returns>
+        /// <exception cref="EventNotFoundException">When the event with the given <paramref name="eventId"/> does not
+        /// exist.</exception>
         public async Task<IEnumerable<StateDto>> GetConflictingStatesForEvent(int eventId)
         {
             var conflictingPlannedStates = await _eventsService.GetConflictingStatesForEvent(eventId);
@@ -178,9 +189,11 @@ namespace KachnaOnline.Business.Facades
         /// </summary>
         /// <param name="eventId">ID of the event to update.</param>
         /// <param name="baseEvent"><see ref="KachnaOnline.Dto.Events.BaseEventDto"/> representing the new state.</param>
-        /// <exception cref="EventNotFoundException">When an event with the given <paramref name="eventId"/> does not
-        /// exist.</exception>
-        /// <exception cref="EventManipulationFailedException">When the event cannot be updated.</exception>
+        /// <exception cref="ArgumentNullException">Thrown when the passed <paramref name="modifiedEvent"/> model is null.</exception>
+        /// <exception cref="EventNotFoundException">Thrown when an event with the given <paramref name="eventId"/>
+        /// does not exist.</exception>
+        /// <exception cref="EventReadOnlyException">Thrown when event to be modified has already ended.</exception>
+        /// <exception cref="EventManipulationFailedException">Thrown when event modification has failed.</exception>
         public async Task ModifyEvent(int eventId, BaseEventDto baseEvent)
         {
             await _eventsService.ModifyEvent(eventId, _mapper.Map<ModifiedEvent>(baseEvent));
@@ -191,9 +204,10 @@ namespace KachnaOnline.Business.Facades
         /// </summary>
         /// <param name="eventId">ID of the event to remove.</param>
         /// <returns>A collection of <see cref="StateDto"/> of states linked to the event at the time of deletion.</returns>
-        /// <exception cref="EventNotFoundException">When the event with the given <paramref name="eventId"/> does not
+        /// <exception cref="EventNotFoundException">Thrown when the event with the given <paramref name="eventId"/> does not
         /// exist.</exception>
-        /// <exception cref="EventManipulationFailedException">When the event cannot be deleted.</exception>
+        /// <exception cref="EventManipulationFailedException">Thrown when the event cannot be deleted.</exception>
+        /// <exception cref="EventReadOnlyException">Thrown when event to be removed has already ended.</exception>
         public async Task<IEnumerable<StateDto>> RemoveEvent(int eventId)
         {
             return this.MapPlannedStates(await _eventsService.RemoveEvent(eventId));
@@ -204,6 +218,13 @@ namespace KachnaOnline.Business.Facades
         /// </summary>
         /// <param name="eventId">Event to set linked planned states for.</param>
         /// <param name="plannedStatesToLink">A <see cref="PlannedStatesToLinkDto"/> of states to link to the event.</param>
+        /// <exception cref="EventNotFoundException">Thrown when an event with the given <paramref name="eventId"/>
+        /// does not exist.</exception>
+        /// <exception cref="EventManipulationFailedException">Thrown when linked planned states cannot be unlinked from the event.</exception>
+        /// <exception cref="StateReadOnlyException">Thrown when planned state to be unlinked from the event has already started or ended.</exception>
+        /// <exception cref="EventReadOnlyException">Thrown when event to unlinked linked states from has already ended.</exception>
+        /// <exception cref="LinkingStateToEventException">Thrown when linking planned states to the event is not possible.</exception>
+        /// <exception cref="StateNotFoundException">Thrown when planned state to be linked to the event has not been found.</exception>
         public async Task SetLinkedPlannedStatesForEvent(int eventId, PlannedStatesToLinkDto plannedStatesToLink)
         {
             await _eventsService.SetLinkedPlannedStatesForEvent(eventId, plannedStatesToLink.PlannedStateIds);
@@ -213,6 +234,11 @@ namespace KachnaOnline.Business.Facades
         /// Clears (unlinks) the current linked states from the event specified by <paramref name="eventId"/>.
         /// </summary>
         /// <param name="eventId">Event to unlink linked planned states from.</param>
+        /// <exception cref="EventNotFoundException">Thrown when an event with the given <paramref name="eventId"/>
+        /// does not exist.</exception>
+        /// <exception cref="EventManipulationFailedException">Thrown when linked planned states cannot be unlinked from the event.</exception>
+        /// <exception cref="StateReadOnlyException">Thrown when planned state to be unlinked from the event has already started or ended.</exception>
+        /// <exception cref="EventReadOnlyException">Thrown when event to unlinked linked states from has already ended.</exception>
         public async Task ClearLinkedPlannedStatesForEvent(int eventId)
         {
             await _eventsService.ClearLinkedPlannedStatesForEvent(eventId);
@@ -223,6 +249,13 @@ namespace KachnaOnline.Business.Facades
         /// </summary>
         /// <param name="eventId">ID of the event to link states to.</param>
         /// <param name="plannedStatesToLink">A list of planned state IDs to link to the event specified by <paramref name="eventId"/>.</param>
+        /// <exception cref="EventNotFoundException">Thrown when an event with the given <paramref name="eventId"/>
+        /// does not exist.</exception>
+        /// <exception cref="EventManipulationFailedException">Thrown when planned states cannot be linked to the event.</exception>
+        /// <exception cref="LinkingStateToEventException">Thrown when linking planned states to the event is not possible.</exception>
+        /// <exception cref="StateReadOnlyException">Thrown when planned state to be linked to the event has already started or ended.</exception>
+        /// <exception cref="StateNotFoundException">Thrown when planned state to be linked to the event has not been found.</exception>
+        /// <exception cref="EventReadOnlyException">Thrown when event to be linked to has already ended.</exception>
         public async Task LinkPlannedStatesToEvent(int eventId, PlannedStatesToLinkDto plannedStatesToLink)
         {
             await _eventsService.LinkPlannedStatesToEvent(eventId, plannedStatesToLink.PlannedStateIds);
@@ -232,18 +265,11 @@ namespace KachnaOnline.Business.Facades
         /// Get states linked to the event.
         /// </summary>
         /// <param name="eventId">The event to get the linked states for.</param>
+        /// <exception cref="EventNotFoundException">Thrown when the event with the given <paramref name="eventId"/> does not
+        /// exist.</exception>
         public async Task<IEnumerable<StateDto>> GetLinkedStatesForEvent(int eventId)
         {
             return this.MapPlannedStates(await _eventsService.GetLinkedStates(eventId));
-        }
-
-        /// <summary>
-        /// Unlinks the specified linked state from any event.
-        /// </summary>
-        /// <param name="stateId">ID of the planned state to be unlinked from any event.</param>
-        public async Task UnlinkStateFromEvent(int stateId)
-        {
-            await _eventsService.UnlinkStateFromEvent(stateId);
         }
     }
 }

--- a/KachnaOnline.Business/Mappings/EventsMappings.cs
+++ b/KachnaOnline.Business/Mappings/EventsMappings.cs
@@ -18,7 +18,6 @@ namespace KachnaOnline.Business.Mappings
             this.CreateMap<EventEntity, Event>()
                 .ForMember(e => e.LinkedPlannedStateIds, options =>
                     options.MapFrom(e => e.LinkedPlannedStates.Select(state => state.Id).ToList()));
-            this.CreateMap<Event, EventEntity>();
 
             this.CreateMap<EventEntity, EventWithLinkedStates>()
                 .ForMember(e => e.LinkedStates, options =>
@@ -26,14 +25,11 @@ namespace KachnaOnline.Business.Mappings
                 .ForMember(e => e.LinkedPlannedStateIds, options =>
                     options.MapFrom(e => e.LinkedPlannedStates.Select(state => state.Id).ToList()));
 
-            this.CreateMap<EventEntity, NewEvent>().ReverseMap();
-            this.CreateMap<EventEntity, ModifiedEvent>()
-                .ForMember(e => e.LinkedPlannedStateIds, options =>
-                    options.MapFrom(e => e.LinkedPlannedStates.Select(state => state.Id).ToList()));
+            this.CreateMap<NewEvent, EventEntity>();
             this.CreateMap<ModifiedEvent, EventEntity>();
 
-            this.CreateMap<Event, EventDto>().ReverseMap();
-            this.CreateMap<Event, ManagerEventDto>().ReverseMap();
+            this.CreateMap<Event, EventDto>();
+            this.CreateMap<Event, ManagerEventDto>();
 
             this.CreateMap<EventWithLinkedStates, EventWithLinkedStatesDto>()
                 .ForMember(e => e.LinkedStatesDtos, options =>
@@ -42,8 +38,8 @@ namespace KachnaOnline.Business.Mappings
                 .ForMember(e => e.LinkedStatesDtos, options =>
                     options.MapFrom(e => e.LinkedStates));
 
-            this.CreateMap<NewEvent, BaseEventDto>().ReverseMap();
-            this.CreateMap<ModifiedEvent, BaseEventDto>().ReverseMap();
+            this.CreateMap<BaseEventDto, NewEvent>();
+            this.CreateMap<BaseEventDto, ModifiedEvent>();
         }
     }
 }

--- a/KachnaOnline.Business/Mappings/EventsMappings.cs
+++ b/KachnaOnline.Business/Mappings/EventsMappings.cs
@@ -1,9 +1,12 @@
 // EventsMappings.cs
 // Author: David Chocholatý
 
+using System.Linq;
 using AutoMapper;
+using AutoMapper.Internal;
 using KachnaOnline.Business.Models.Events;
 using KachnaOnline.Dto.Events;
+using Microsoft.EntityFrameworkCore.ChangeTracking;
 using EventEntity = KachnaOnline.Data.Entities.Events.Event;
 
 namespace KachnaOnline.Business.Mappings
@@ -12,11 +15,33 @@ namespace KachnaOnline.Business.Mappings
     {
         public EventMappings()
         {
-            this.CreateMap<EventEntity, Event>().ReverseMap();
+            this.CreateMap<EventEntity, Event>()
+                .ForMember(e => e.LinkedPlannedStateIds, options =>
+                    options.MapFrom(e => e.LinkedPlannedStates.Select(state => state.Id).ToList()));
+            this.CreateMap<Event, EventEntity>();
+
+            this.CreateMap<EventEntity, EventWithLinkedStates>()
+                .ForMember(e => e.LinkedStates, options =>
+                    options.MapFrom(e => e.LinkedPlannedStates))
+                .ForMember(e => e.LinkedPlannedStateIds, options =>
+                    options.MapFrom(e => e.LinkedPlannedStates.Select(state => state.Id).ToList()));
+
             this.CreateMap<EventEntity, NewEvent>().ReverseMap();
-            this.CreateMap<EventEntity, ModifiedEvent>().ReverseMap();
+            this.CreateMap<EventEntity, ModifiedEvent>()
+                .ForMember(e => e.LinkedPlannedStateIds, options =>
+                    options.MapFrom(e => e.LinkedPlannedStates.Select(state => state.Id).ToList()));
+            this.CreateMap<ModifiedEvent, EventEntity>();
+
             this.CreateMap<Event, EventDto>().ReverseMap();
             this.CreateMap<Event, ManagerEventDto>().ReverseMap();
+
+            this.CreateMap<EventWithLinkedStates, EventWithLinkedStatesDto>()
+                .ForMember(e => e.LinkedStatesDtos, options =>
+                    options.MapFrom(e => e.LinkedStates));
+            this.CreateMap<EventWithLinkedStates, ManagerEventWithLinkedStatesDto>()
+                .ForMember(e => e.LinkedStatesDtos, options =>
+                    options.MapFrom(e => e.LinkedStates));
+
             this.CreateMap<NewEvent, BaseEventDto>().ReverseMap();
             this.CreateMap<ModifiedEvent, BaseEventDto>().ReverseMap();
         }

--- a/KachnaOnline.Business/Models/Events/EventWithLinkedStates.cs
+++ b/KachnaOnline.Business/Models/Events/EventWithLinkedStates.cs
@@ -1,0 +1,20 @@
+// EventWithLinkedStates.cs
+// Author: David Chocholatý
+
+using System.Collections.Generic;
+using KachnaOnline.Business.Models.ClubStates;
+using KachnaOnline.Dto.Events;
+
+namespace KachnaOnline.Business.Models.Events
+{
+    /// <summary>
+    /// A model representing an event with linked states.
+    /// </summary>
+    public class EventWithLinkedStates : Event
+    {
+        /// <summary>
+        /// A list of linked states.
+        /// </summary>
+        public List<State> LinkedStates { get; set; }
+    }
+}

--- a/KachnaOnline.Business/Models/Events/ModifiedEvent.cs
+++ b/KachnaOnline.Business/Models/Events/ModifiedEvent.cs
@@ -2,6 +2,7 @@
 // Author: David Chocholatý
 
 using System;
+using System.Collections.Generic;
 
 namespace KachnaOnline.Business.Models.Events
 {
@@ -59,6 +60,6 @@ namespace KachnaOnline.Business.Models.Events
         /// <summary>
         /// The linked planned states IDs.
         /// </summary>
-        public int[] LinkedPlannedStateIds { get; set; }
+        public List<int> LinkedPlannedStateIds { get; set; }
     }
 }

--- a/KachnaOnline.Business/Services/Abstractions/IClubStateService.cs
+++ b/KachnaOnline.Business/Services/Abstractions/IClubStateService.cs
@@ -209,5 +209,15 @@ namespace KachnaOnline.Business.Services.Abstractions
         /// <exception cref="StateNotFoundException">No state is currently active.</exception>
         /// <returns></returns>
         Task CloseNow(int closedByUserId);
+
+        /// <summary>
+        /// Sets state <see cref="State.EventId"/> to null (unlinks that state from any event) to state specified by <paramref name="stateId"/>.
+        /// </summary>
+        /// <param name="stateId">State ID to set its <see cref="State.EventId"/> to null.</param>
+        /// <exception cref="StateReadOnlyException">Thrown when planned state to be unlinked from the event has already started or ended.</exception>
+        /// <exception cref="StateNotFoundException">Thrown when planned state to be unlinked from the event has not been found.</exception>
+        /// <exception cref="StateNotAssociatedToEventException">Thrown when planned states is not associated to any event.</exception>
+        Task UnlinkStateFromEvent(int stateId);
+
     }
 }

--- a/KachnaOnline.Business/Services/Abstractions/IEventsService.cs
+++ b/KachnaOnline.Business/Services/Abstractions/IEventsService.cs
@@ -48,6 +48,7 @@ namespace KachnaOnline.Business.Services.Abstractions
         /// <param name="from">If not null, only returns events with their from date being after or equal to the specified value.</param>
         /// <param name="to">If not null, only returns events with their to date being before or equal to the specified value.</param>
         /// <returns>A Collection of <see cref="Event"/> or an empty list if no there is no event planned.</returns>
+        /// <exception cref="ArgumentException">Thrown when <paramref name="from"/> or <paramref name="to"/> are invalid.</exception>
         Task<ICollection<Event>> GetEvents(DateTime? from = null, DateTime? to = null);
 
         /// <summary>
@@ -90,20 +91,11 @@ namespace KachnaOnline.Business.Services.Abstractions
         /// <remarks>
         /// All planned states that were linked to the event have their reference to the event set to null.
         /// </remarks>>
-        /// <exception cref="EventNotFoundException">When the event with the given <paramref name="eventId"/> does not
+        /// <exception cref="EventNotFoundException">Thrown when the event with the given <paramref name="eventId"/> does not
         /// exist.</exception>
-        /// <exception cref="EventManipulationFailedException">thrown when the event cannot be deleted.</exception>
+        /// <exception cref="EventManipulationFailedException">Thrown when the event cannot be deleted.</exception>
+        /// <exception cref="EventReadOnlyException">Thrown when event to be removed has already ended.</exception>
         Task<ICollection<State>> RemoveEvent(int eventId);
-
-        /// <summary>
-        /// Sets state <see cref="State.EventId"/> to null to states specified by <paramref name="stateId"/>;
-        /// </summary>
-        /// <param name="stateId">State ID to set its <see cref="State.EventId"/> to null.</param>
-        /// <exception cref="EventManipulationFailedException">Thrown when linked planned states cannot be unlinked from the event.</exception>
-        /// <exception cref="StateReadOnlyException">Thrown when planned state to be unlinked from the event has already started or ended.</exception>
-        /// <exception cref="StateNotFoundException">Thrown when planned state to be unlinked from the event has not been found.</exception>
-        /// <exception cref="StateNotAssociatedToEventException">Thrown when planned states is not associated to any event.</exception>
-        Task UnlinkStateFromEvent(int stateId);
 
         /// <summary>
         /// Changes details of an event specified by <paramref name="eventId"/>. Projects these changes into all planned states linked to this event. State records from the past are not changed.
@@ -162,6 +154,13 @@ namespace KachnaOnline.Business.Services.Abstractions
         /// </summary>
         /// <param name="eventId">Event to set linked planned states for.</param>
         /// <param name="plannedStatesToLinkIds">IDs of states to link to the event.</param>
+        /// <exception cref="EventNotFoundException">Thrown when an event with the given <paramref name="eventId"/>
+        /// does not exist.</exception>
+        /// <exception cref="EventManipulationFailedException">Thrown when linked planned states cannot be unlinked from the event.</exception>
+        /// <exception cref="StateReadOnlyException">Thrown when planned state to be unlinked from the event has already started or ended.</exception>
+        /// <exception cref="EventReadOnlyException">Thrown when event to unlinked linked states from has already ended.</exception>
+        /// <exception cref="LinkingStateToEventException">Thrown when linking planned states to the event is not possible.</exception>
+        /// <exception cref="StateNotFoundException">Thrown when planned state to be linked to the event has not been found.</exception>
         Task SetLinkedPlannedStatesForEvent(int eventId, IEnumerable<int> plannedStatesToLinkIds);
 
         /// <summary>

--- a/KachnaOnline.Business/Services/EventsService.cs
+++ b/KachnaOnline.Business/Services/EventsService.cs
@@ -70,7 +70,7 @@ namespace KachnaOnline.Business.Services
         /// <inheritDoc />
         public async Task<EventWithLinkedStates> GetEventWithLinkedStates(int eventId)
         {
-            var eventEntity = await _eventsRepository.GetWithLinkedStates(eventId);
+            var eventEntity = await _eventsRepository.Get(eventId);
             if (eventEntity is null)
                 throw new EventNotFoundException();
 
@@ -223,7 +223,7 @@ namespace KachnaOnline.Business.Services
             if (modifiedEvent is null)
                 throw new ArgumentNullException(nameof(modifiedEvent));
 
-            var eventEntity = await _eventsRepository.GetWithLinkedStates(eventId);
+            var eventEntity = await _eventsRepository.Get(eventId);
             if (eventEntity is null)
                 throw new EventNotFoundException();
 
@@ -328,7 +328,7 @@ namespace KachnaOnline.Business.Services
         /// <inheritdoc />
         public async Task<ICollection<State>> GetLinkedStates(int eventId)
         {
-            var eventEntity = await _eventsRepository.GetWithLinkedStates(eventId);
+            var eventEntity = await _eventsRepository.Get(eventId);
             if (eventEntity is null)
                 throw new EventNotFoundException();
 
@@ -345,7 +345,7 @@ namespace KachnaOnline.Business.Services
         /// <inheritdoc />
         public async Task<ICollection<State>> RemoveEvent(int eventId)
         {
-            var eventEntity = await _eventsRepository.GetWithLinkedStates(eventId);
+            var eventEntity = await _eventsRepository.Get(eventId);
             if (eventEntity is null)
                 throw new EventNotFoundException();
 

--- a/KachnaOnline.Dto/Events/BaseEventDto.cs
+++ b/KachnaOnline.Dto/Events/BaseEventDto.cs
@@ -7,7 +7,7 @@ using System.ComponentModel.DataAnnotations;
 namespace KachnaOnline.Dto.Events
 {
     /// <summary>
-    /// Represents an event modification.
+    /// Represents a base event DTO.
     /// </summary>
     public class BaseEventDto
     {
@@ -80,7 +80,7 @@ namespace KachnaOnline.Dto.Events
         /// <summary>
         /// The linked planned states IDs.
         /// </summary>
-        /// <example>[4213423, 625345, 2143234]</example>
+        /// <example>[357, 358, 360]</example>
         public int[] LinkedPlannedStateIds { get; set; }
     }
 }

--- a/KachnaOnline.Dto/Events/EventWithLinkedStatesDto.cs
+++ b/KachnaOnline.Dto/Events/EventWithLinkedStatesDto.cs
@@ -1,0 +1,20 @@
+// EventWithLinkedStatesDto.cs
+// Author: David Chocholatý
+
+using System.Collections.Generic;
+using KachnaOnline.Dto.ClubStates;
+
+namespace KachnaOnline.Dto.Events
+{
+    /// <summary>
+    /// Represents a past, a current or a future event with linked states.
+    /// </summary>
+    public class EventWithLinkedStatesDto: EventDto
+    {
+        /// <summary>
+        /// A list of states linked to the event.
+        /// </summary>
+        /// <example>[23, 24, 26]</example>
+        public List<StateDto> LinkedStatesDtos { get; set; }
+    }
+}

--- a/KachnaOnline.Dto/Events/ManagerEventWithLinkedStatesDto.cs
+++ b/KachnaOnline.Dto/Events/ManagerEventWithLinkedStatesDto.cs
@@ -1,12 +1,12 @@
-// ManagerEventDto.cs
+// ManagerEventWithLinkedStatesDto.cs
 // Author: David Chocholatý
 
 namespace KachnaOnline.Dto.Events
 {
     /// <summary>
-    /// Represents a past, a current or a future event as seen by events manager.
+    /// Represents a past, a current or a future event with linked planned states as seen by events manager.
     /// </summary>
-    public class ManagerEventDto : EventDto
+    public class ManagerEventWithLinkedStatesDto : EventWithLinkedStatesDto
     {
         /// <summary>
         /// An ID of the events manager who created this event.

--- a/KachnaOnline.Dto/Events/PlannedStatesToLinkDto.cs
+++ b/KachnaOnline.Dto/Events/PlannedStatesToLinkDto.cs
@@ -1,0 +1,23 @@
+// PlannedStatesToLinkDto.cs
+// Author: David Chocholatý
+
+using System.ComponentModel.DataAnnotations;
+
+namespace KachnaOnline.Dto.Events
+{
+    /// <summary>
+    /// Represents a list of planned states to link to an event.
+    /// </summary>
+    public class PlannedStatesToLinkDto
+    {
+        /// <summary>
+        /// IDs of the planned states to be linked to the event.
+        /// </summary>
+        /// <remarks>
+        /// Put an empty list to unlink all already linked planned states from the event.
+        /// </remarks>
+        /// <example>[342, 343, 345]</example>
+        [Required]
+        public int[] PlannedStateIds { get; set; }
+    }
+}


### PR DESCRIPTION
This PR adds functionality, which allow the user to:
- see conflicting planned states for specified event,
- automatically inform the events' manager about conflicting planned states when a new event has been planned, 
- link planned states to the event,
- see states linked to the event,
- get detail of the event with detail of linked planned states included,
- modify set of linked planned states for events (set, link additional) and
- unlink separate or all linked states from the event.