### PR TITLE
State Discord notifications and more

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@ riderModule.iml
 /_ReSharper.Caches/
 *.DotSettings.user
 KachnaOnline.App/UploadedImages
+Publish/

--- a/KachnaOnline.App/Startup.cs
+++ b/KachnaOnline.App/Startup.cs
@@ -103,8 +103,7 @@ namespace KachnaOnline.App
         /// An <see cref="IWebHostEnvironment" /> instance that contains information about the current
         /// environment.
         /// </param>
-        /// <param name="dbContext">An <see cref="AppDbContext"/> database context instance.</param>
-        public void Configure(IApplicationBuilder app, IWebHostEnvironment env, AppDbContext dbContext)
+        public void Configure(IApplicationBuilder app, IWebHostEnvironment env)
         {
             app.UsePathBase("/kachna/api");
 
@@ -155,19 +154,6 @@ namespace KachnaOnline.App
 
             // Map controller endpoints using the default mapping strategy.
             app.UseEndpoints(endpoints => { endpoints.MapControllers(); });
-
-            // Run migrations (optionally).
-            if (Environment.CommandLine.Contains("--migrate-db"))
-            {
-                dbContext.Database.Migrate();
-            }
-
-            // Add initial data (optionally).
-            if (Environment.CommandLine.Contains("--bootstrap-db"))
-            {
-                var dbBootstrapper = new DataBootstrapper(dbContext);
-                dbBootstrapper.BootstrapDatabase();
-            }
         }
     }
 }

--- a/KachnaOnline.App/appsettings.json
+++ b/KachnaOnline.App/appsettings.json
@@ -23,8 +23,7 @@
     "CacheExpirationTimesSeconds": {
       "Offers": 600,
       "Taps": 600,
-      "Leaderboard": 30,
-      "Users": 300
+      "Leaderboard": 30
     }
   },
   "Jwt": {
@@ -39,12 +38,20 @@
     "ExtensionDays": 7,
     "NotificationServiceIntervalMinutes": 5,
     "NotifyBeforeExpirationDays": 3,
-    "SuWebhookUrl": ""
+    "SuDiscordWebhookUrl": ""
   },
   "Mail": {
     "Host": "smtp.gmail.com",
     "Port": 587,
     "FromAddress": "",
-    "Password": ""
+    "Username": "",
+    "Password": "",
+    "UseSsl": true,
+    "DisplayName": "Kachna Online"
+  },
+  "States": {
+    "MaximumDaysSpanForStatesListAllowed": 62,
+    "SuDiscordWebhookUrl": "",
+    "FitwideDiscordWebhookUrl": ""
   }
 }

--- a/KachnaOnline.Business/Configuration/BoardGamesOptions.cs
+++ b/KachnaOnline.Business/Configuration/BoardGamesOptions.cs
@@ -29,6 +29,6 @@ namespace KachnaOnline.Business.Configuration
         /// <summary>
         /// Webhook URL to Student Union Discord for board games related information.
         /// </summary>
-        public string SuWebhookUrl { get; set; }
+        public string SuDiscordWebhookUrl { get; set; }
     }
 }

--- a/KachnaOnline.Business/Configuration/ClubStateOptions.cs
+++ b/KachnaOnline.Business/Configuration/ClubStateOptions.cs
@@ -6,5 +6,7 @@ namespace KachnaOnline.Business.Configuration
     public class ClubStateOptions
     {
         public int MaximumDaysSpanForStatesListAllowed { get; set; } = 62;
+        public string SuDiscordWebhookUrl { get; set; }
+        public string FitwideDiscordWebhookUrl { get; set; }
     }
 }

--- a/KachnaOnline.Business/Extensions/StartupExtensions.cs
+++ b/KachnaOnline.Business/Extensions/StartupExtensions.cs
@@ -60,7 +60,7 @@ namespace KachnaOnline.Business.Extensions
 
             // Add state planner.
             services.AddTransient<IStateTransitionHandler, SaveEndedDateTimeTransitionHandler>();
-            services.AddTransient<IStateTransitionHandler, DiscordTransitionHandler>();
+            services.AddTransient<IStateTransitionHandler, SuDiscordTransitionHandler>();
             services.AddScoped<IStateTransitionService, StateTransitionService>();
             services.AddSingleton<IStatePlannerService, StatePlannerService>();
             services.AddHostedService<StatePlannerBackgroundService>();

--- a/KachnaOnline.Business/Extensions/StartupExtensions.cs
+++ b/KachnaOnline.Business/Extensions/StartupExtensions.cs
@@ -61,6 +61,7 @@ namespace KachnaOnline.Business.Extensions
             // Add state planner.
             services.AddTransient<IStateTransitionHandler, SaveEndedDateTimeTransitionHandler>();
             services.AddTransient<IStateTransitionHandler, SuDiscordTransitionHandler>();
+            services.AddTransient<IStateTransitionHandler, FitwideDiscordTransitionHandler>();
             services.AddScoped<IStateTransitionService, StateTransitionService>();
             services.AddSingleton<IStatePlannerService, StatePlannerService>();
             services.AddHostedService<StatePlannerBackgroundService>();

--- a/KachnaOnline.Business/Extensions/UserExtensions.cs
+++ b/KachnaOnline.Business/Extensions/UserExtensions.cs
@@ -1,0 +1,21 @@
+// UserExtensions.cs
+// Author: Ondřej Ondryáš
+
+using KachnaOnline.Business.Models.Users;
+
+namespace KachnaOnline.Business.Extensions
+{
+    public static class UserExtensions
+    {
+        public static string GetDiscordMention(this User user, bool showName = false)
+        {
+            if (user is null)
+                return null;
+
+            if (!user.DiscordId.HasValue)
+                return user.Nickname ?? (showName ? user.Name : null);
+
+            return $"<@{user.DiscordId.Value}>";
+        }
+    }
+}

--- a/KachnaOnline.Business/Services/BoardGamesNotifications/NotificationHandlers/MailBoardGamesNotificationHandler.cs
+++ b/KachnaOnline.Business/Services/BoardGamesNotifications/NotificationHandlers/MailBoardGamesNotificationHandler.cs
@@ -72,8 +72,7 @@ namespace KachnaOnline.Business.Services.BoardGamesNotifications.NotificationHan
             // TODO: Cache SMTP clients. Making a new one for each e-mail may lead to starvation.
 
             var config = _smtpOptionsMonitor.CurrentValue;
-            if (string.IsNullOrEmpty(config.FromAddress) || string.IsNullOrEmpty(config.Host) ||
-                string.IsNullOrEmpty(config.Password))
+            if (string.IsNullOrEmpty(config.FromAddress) || string.IsNullOrEmpty(config.Host))
             {
                 _logger.LogError("SMTP authentication not available.");
                 return;
@@ -87,10 +86,14 @@ namespace KachnaOnline.Business.Services.BoardGamesNotifications.NotificationHan
                 Host = config.Host,
                 Port = config.Port,
                 EnableSsl = config.UseSsl,
-                DeliveryMethod = SmtpDeliveryMethod.Network,
-                UseDefaultCredentials = false,
-                Credentials = new NetworkCredential(config.Username, config.Password)
+                DeliveryMethod = SmtpDeliveryMethod.Network
             };
+
+            if (!string.IsNullOrEmpty(config.Username) || !string.IsNullOrEmpty(config.Password))
+            {
+                smtp.UseDefaultCredentials = false;
+                smtp.Credentials = new NetworkCredential(config.Username, config.Password);
+            }
 
             var message = new MailMessage(fromAddress, toAddress)
             {
@@ -130,7 +133,7 @@ namespace KachnaOnline.Business.Services.BoardGamesNotifications.NotificationHan
                 var expiration = item.ExpiresOn.Value;
                 // TODO: possibly include a link to frontend card where the game can be extended.
                 var message = $@"Ahoj,<br><br>
-Tvá výpůjčka deskové hry <b>{game.Name}</b> již brzy vyprší, konkrétně 
+Tvá výpůjčka deskové hry <b>{game.Name}</b> již brzy vyprší, konkrétně
 <b>{expiration:dd. MM. yyyy}</b>.
 Domluv se, prosím, s někým ze Studentské unie na vrácení hry zpět do klubu. V případě, že
 se ti hra zalíbila a rád bys ji měl*a půjčenou ještě déle, můžeš na webu Kachna Online požádat
@@ -177,7 +180,7 @@ Tvoje Kachna Online";
 
                 // TODO: possibly include a link to frontend card where the game can be extended.
                 var message = $@"Ahoj,<br><br>
-Tvá výpůjčka deskové hry <b>{game.Name}</b> vypršela. 
+Tvá výpůjčka deskové hry <b>{game.Name}</b> vypršela.
 Domluv se, prosím, s někým ze Studentské unie na vrácení hry zpět do klubu. V případě, že
 se ti hra zalíbila a rád bys ji měl*a půjčenou ještě déle, můžeš na webu Kachna Online požádat
 o prodloužení nebo ti ji může prodloužit člen Studentské unie, pokud se s ním domluvíš.<br><br>

--- a/KachnaOnline.Business/Services/ClubStateService.cs
+++ b/KachnaOnline.Business/Services/ClubStateService.cs
@@ -941,6 +941,8 @@ namespace KachnaOnline.Business.Services
 
                 currentStateEntity.Ended = DateTime.Now;
                 currentStateEntity.ClosedById = closedByUserId;
+                currentStateEntity.NextPlannedStateId = null;
+
                 currentStateId = currentStateEntity.Id;
                 await _unitOfWork.SaveChanges();
             }
@@ -961,7 +963,7 @@ namespace KachnaOnline.Business.Services
             TaskUtils.FireAndForget(_serviceProvider, _logger, async (services, _) =>
             {
                 var transitionService = services.GetRequiredService<IStateTransitionService>();
-                await transitionService.TriggerStateEnd(currentStateId);
+                await transitionService.TriggerStateEnd(currentStateId, null);
             });
         }
 

--- a/KachnaOnline.Business/Services/Discord/DiscordWebhookClient.cs
+++ b/KachnaOnline.Business/Services/Discord/DiscordWebhookClient.cs
@@ -1,0 +1,97 @@
+// DiscordWebhookClient.cs
+// Author: Ondřej Ondryáš, František Nečas
+
+using System;
+using System.Net.Http;
+using System.Text;
+using System.Threading.Tasks;
+using KachnaOnline.Business.Models.Discord;
+using Microsoft.Extensions.Logging;
+using Newtonsoft.Json;
+
+namespace KachnaOnline.Business.Services.Discord
+{
+    public abstract class DiscordWebhookClient
+    {
+        private readonly string _webhookUrl;
+        private readonly IHttpClientFactory _httpClientFactory;
+        private readonly ILogger<DiscordWebhookClient> _logger;
+
+        internal DiscordWebhookClient(IHttpClientFactory httpClientFactory, ILogger<DiscordWebhookClient> logger)
+        {
+            _httpClientFactory = httpClientFactory;
+            _logger = logger;
+        }
+
+        internal DiscordWebhookClient(string webhookUrl, IHttpClientFactory httpClientFactory,
+            ILogger<DiscordWebhookClient> logger) : this(httpClientFactory, logger)
+        {
+            _webhookUrl = webhookUrl;
+        }
+
+        /// <summary>
+        /// Sends a Discord webhook message.
+        /// </summary>
+        /// <param name="message">Message to send.</param>
+        /// <param name="wait">Whether to wait for server message confirmation. False by default.</param>
+        /// <param name="webhookUrl">URL of the target Discord webhook.</param>
+        /// <returns>Message model if <paramref name="wait"/> was true and the request succeeded, null otherwise.</returns>
+        protected async Task<DiscordMessage> SendWebhookMessage(string message, bool wait = false,
+            string webhookUrl = null)
+        {
+            webhookUrl ??= _webhookUrl;
+
+            if (string.IsNullOrEmpty(webhookUrl))
+            {
+                _logger.LogError("Webhook URL not available");
+                return null;
+            }
+
+            if (string.IsNullOrEmpty(message))
+            {
+                _logger.LogError("Empty message.");
+                return null;
+            }
+
+            using var client = _httpClientFactory.CreateClient();
+            var content = $"{{ \"content\": \"{message}\" }}";
+            var waitString = wait.ToString().ToLower();
+
+            try
+            {
+                var response = await client.PostAsync($"{webhookUrl}?wait={waitString}",
+                    new StringContent(content, Encoding.UTF8, "application/json"));
+                response.EnsureSuccessStatusCode();
+
+                var responseData = await response.Content.ReadAsStringAsync();
+                _logger.LogDebug("Webhook response payload: {data}", responseData);
+                return JsonConvert.DeserializeObject<DiscordMessage>(responseData);
+            }
+            catch (Exception e)
+            {
+                _logger.LogError(e, "Cannot send Discord webhook message");
+                return null;
+            }
+        }
+
+
+        /// <summary>
+        /// Deletes a Discord webhook message.
+        /// </summary>
+        /// <param name="messageId">ID of the message to delete.</param>
+        /// <param name="webhookUrl">URL of the target Discord webhook.</param>
+        protected async Task DeleteWebhookMessage(ulong messageId, string webhookUrl = null)
+        {
+            webhookUrl ??= _webhookUrl;
+
+            if (string.IsNullOrEmpty(webhookUrl))
+            {
+                _logger.LogError("Webhook URL not available");
+                return;
+            }
+
+            using var client = _httpClientFactory.CreateClient();
+            await client.DeleteAsync($"{webhookUrl}/messages/{messageId}");
+        }
+    }
+}

--- a/KachnaOnline.Business/Services/StatePlanning/Abstractions/IStateTransitionHandler.cs
+++ b/KachnaOnline.Business/Services/StatePlanning/Abstractions/IStateTransitionHandler.cs
@@ -11,17 +11,19 @@ namespace KachnaOnline.Business.Services.StatePlanning.Abstractions
     public interface IStateTransitionHandler
     {
         /// <summary>
-        /// Perform this handler's action for the start of the specified state. 
+        /// Perform this handler's action for the start of the specified state.
         /// </summary>
         /// <param name="stateId">The ID of the state that has started.</param>
+        /// <param name="previousStateId">The ID of the previous state. Null if no state directly precedes this one.</param>
         /// <returns>A <see cref="Task"/> that represents the asynchronous operation.</returns>
-        Task PerformStartAction(int stateId);
+        Task PerformStartAction(int stateId, int? previousStateId);
 
         /// <summary>
-        /// Perform this handler's action for the end of the specified state. 
+        /// Perform this handler's action for the end of the specified state.
         /// </summary>
         /// <param name="stateId">The ID of the state that has ended.</param>
+        /// <param name="nextStateId">The ID of the following state. Null if no state comes right after this one.</param>
         /// <returns>A <see cref="Task"/> that represents the asynchronous operation.</returns>
-        Task PerformEndAction(int stateId);
+        Task PerformEndAction(int stateId, int? nextStateId);
     }
 }

--- a/KachnaOnline.Business/Services/StatePlanning/Abstractions/IStateTransitionService.cs
+++ b/KachnaOnline.Business/Services/StatePlanning/Abstractions/IStateTransitionService.cs
@@ -15,14 +15,16 @@ namespace KachnaOnline.Business.Services.StatePlanning.Abstractions
         /// Performs the state start actions.
         /// </summary>
         /// <param name="stateId">The ID of the state that has started.</param>
+        /// <param name="previousStateId">The ID of the previous state. Null if no state directly precedes this one.</param>
         /// <returns>A <see cref="Task"/> that represents the asynchronous operation.</returns>
-        Task TriggerStateStart(int stateId);
+        Task TriggerStateStart(int stateId, int? previousStateId);
 
         /// <summary>
         /// Performs the state end actions.
         /// </summary>
         /// <param name="stateId">The ID of the state that has ended.</param>
+        /// <param name="nextStateId">The ID of the following state. Null if no state comes right after this one.</param>
         /// <returns>A <see cref="Task"/> that represents the asynchronous operation.</returns>
-        Task TriggerStateEnd(int stateId);
+        Task TriggerStateEnd(int stateId, int? nextStateId);
     }
 }

--- a/KachnaOnline.Business/Services/StatePlanning/StatePlannerBackgroundService.cs
+++ b/KachnaOnline.Business/Services/StatePlanning/StatePlannerBackgroundService.cs
@@ -137,7 +137,7 @@ namespace KachnaOnline.Business.Services.StatePlanning
                     // Process the triggers
                     if (nextTransition.IsStateEnd)
                     {
-                        await transitionService.TriggerStateEnd(nextTransition.StateId);
+                        await transitionService.TriggerStateEnd(nextTransition.StateId, nextTransition.NextStateId);
 
                         if (nextTransition.NextStateId.HasValue)
                         {
@@ -145,12 +145,13 @@ namespace KachnaOnline.Business.Services.StatePlanning
                                 "Invoking transition triggers for state {NextStateId} (end transition: {IsEndTransition}).",
                                 nextTransition.NextStateId.Value, false);
 
-                            await transitionService.TriggerStateStart(nextTransition.NextStateId.Value);
+                            await transitionService.TriggerStateStart(nextTransition.NextStateId.Value,
+                                nextTransition.StateId);
                         }
                     }
                     else
                     {
-                        await transitionService.TriggerStateStart(nextTransition.StateId);
+                        await transitionService.TriggerStateStart(nextTransition.StateId, null);
                     }
                 });
             }

--- a/KachnaOnline.Business/Services/StatePlanning/StateTransitionService.cs
+++ b/KachnaOnline.Business/Services/StatePlanning/StateTransitionService.cs
@@ -23,7 +23,7 @@ namespace KachnaOnline.Business.Services.StatePlanning
         }
 
         /// <inheritdoc />
-        public async Task TriggerStateStart(int stateId)
+        public async Task TriggerStateStart(int stateId, int? previousStateId)
         {
             _logger.LogDebug("Processing trigger actions for the start of state {StateId}.", stateId);
 
@@ -31,7 +31,7 @@ namespace KachnaOnline.Business.Services.StatePlanning
             {
                 try
                 {
-                    await transitionHandler.PerformStartAction(stateId);
+                    await transitionHandler.PerformStartAction(stateId, previousStateId);
                 }
                 catch (Exception e)
                 {
@@ -42,7 +42,7 @@ namespace KachnaOnline.Business.Services.StatePlanning
         }
 
         /// <inheritdoc />
-        public async Task TriggerStateEnd(int stateId)
+        public async Task TriggerStateEnd(int stateId, int? nextStateId)
         {
             _logger.LogDebug("Processing trigger actions for the end of state {StateId}.", stateId);
 
@@ -50,7 +50,7 @@ namespace KachnaOnline.Business.Services.StatePlanning
             {
                 try
                 {
-                    await transitionHandler.PerformEndAction(stateId);
+                    await transitionHandler.PerformEndAction(stateId, nextStateId);
                 }
                 catch (Exception e)
                 {

--- a/KachnaOnline.Business/Services/StatePlanning/TransitionHandlers/FitwideDiscordTransitionHandler.cs
+++ b/KachnaOnline.Business/Services/StatePlanning/TransitionHandlers/FitwideDiscordTransitionHandler.cs
@@ -1,19 +1,22 @@
 ﻿using System.Net.Http;
 using System.Threading.Tasks;
+using KachnaOnline.Business.Configuration;
+using KachnaOnline.Business.Services.Discord;
 using KachnaOnline.Business.Services.StatePlanning.Abstractions;
 using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
 
 namespace KachnaOnline.Business.Services.StatePlanning.TransitionHandlers
 {
-    public class DiscordTransitionHandler : IStateTransitionHandler
+    public class FitwideDiscordTransitionHandler : DiscordWebhookClient, IStateTransitionHandler
     {
-        private readonly IHttpClientFactory _httpClientFactory;
-        private readonly ILogger<DiscordTransitionHandler> _logger;
+        private readonly ILogger<FitwideDiscordTransitionHandler> _logger;
 
-        public DiscordTransitionHandler(IHttpClientFactory httpClientFactory,
-            ILogger<DiscordTransitionHandler> logger)
+        public FitwideDiscordTransitionHandler(IOptionsMonitor<ClubStateOptions> options,
+            IHttpClientFactory httpClientFactory,
+            ILogger<FitwideDiscordTransitionHandler> logger)
+            : base(options.CurrentValue.FitwideDiscordWebhookUrl, httpClientFactory, logger)
         {
-            _httpClientFactory = httpClientFactory;
             _logger = logger;
         }
 

--- a/KachnaOnline.Business/Services/StatePlanning/TransitionHandlers/FitwideDiscordTransitionHandler.cs
+++ b/KachnaOnline.Business/Services/StatePlanning/TransitionHandlers/FitwideDiscordTransitionHandler.cs
@@ -20,16 +20,14 @@ namespace KachnaOnline.Business.Services.StatePlanning.TransitionHandlers
             _logger = logger;
         }
 
-        public Task PerformStartAction(int stateId)
+        public Task PerformStartAction(int stateId, int? previousStateId)
         {
-            _logger.LogInformation("Discord TH start action for {Id}", stateId);
-            return Task.CompletedTask;
+            throw new System.NotImplementedException();
         }
 
-        public Task PerformEndAction(int stateId)
+        public Task PerformEndAction(int stateId, int? nextStateId)
         {
-            _logger.LogInformation("Discord TH end action for {Id}", stateId);
-            return Task.CompletedTask;
+            throw new System.NotImplementedException();
         }
     }
 }

--- a/KachnaOnline.Business/Services/StatePlanning/TransitionHandlers/FitwideDiscordTransitionHandler.cs
+++ b/KachnaOnline.Business/Services/StatePlanning/TransitionHandlers/FitwideDiscordTransitionHandler.cs
@@ -1,6 +1,14 @@
-﻿using System.Net.Http;
+﻿// FitwideDiscordTransitionHandler.cs
+// Author: Ondřej Ondryáš
+
+using System;
+using System.Net.Http;
 using System.Threading.Tasks;
 using KachnaOnline.Business.Configuration;
+using KachnaOnline.Business.Data.Repositories.Abstractions;
+using KachnaOnline.Business.Extensions;
+using KachnaOnline.Business.Models.ClubStates;
+using KachnaOnline.Business.Services.Abstractions;
 using KachnaOnline.Business.Services.Discord;
 using KachnaOnline.Business.Services.StatePlanning.Abstractions;
 using Microsoft.Extensions.Logging;
@@ -10,24 +18,140 @@ namespace KachnaOnline.Business.Services.StatePlanning.TransitionHandlers
 {
     public class FitwideDiscordTransitionHandler : DiscordWebhookClient, IStateTransitionHandler
     {
+        private const string PeepoLove = "<:peepolove:827833315666558996>";
+        private const string PeepoSushiRoll = "<:peeposushiroll:827833316290854932>";
+        private const string Hypers = "<:HYPERS:493154327318233088>";
+
         private readonly ILogger<FitwideDiscordTransitionHandler> _logger;
+        private readonly IClubStateService _stateService;
+        private readonly IUserService _userService;
+        private readonly IUnitOfWork _unitOfWork;
 
         public FitwideDiscordTransitionHandler(IOptionsMonitor<ClubStateOptions> options,
-            IHttpClientFactory httpClientFactory,
-            ILogger<FitwideDiscordTransitionHandler> logger)
+            IHttpClientFactory httpClientFactory, ILogger<FitwideDiscordTransitionHandler> logger,
+            IClubStateService stateService, IUserService userService, IUnitOfWork unitOfWork)
             : base(options.CurrentValue.FitwideDiscordWebhookUrl, httpClientFactory, logger)
         {
             _logger = logger;
+            _stateService = stateService;
+            _userService = userService;
+            _unitOfWork = unitOfWork;
         }
 
-        public Task PerformStartAction(int stateId, int? previousStateId)
+        public async Task PerformStartAction(int stateId, int? previousStateId)
         {
-            throw new System.NotImplementedException();
+            var state = await _stateService.GetState(stateId);
+            var previousState = previousStateId.HasValue ? await _stateService.GetState(previousStateId.Value) : null;
+
+            var madeBy = state.MadeById.HasValue ? await _userService.GetUser(state.MadeById.Value) : null;
+            var madeByName = madeBy.GetDiscordMention(false);
+
+            string msg = null;
+
+            if (state.Type == StateType.OpenChillzone)
+            {
+                if (!state.PlannedEnd.HasValue)
+                {
+                    _logger.LogCritical("Data inconsistency: chillzone with no planned end (ID {Id}).", state.Id);
+                    return;
+                }
+
+                if (previousState?.Type == StateType.OpenChillzone
+                    && previousState.PlannedEnd.HasValue)
+                {
+                    var timeDelta = state.PlannedEnd.Value - previousState.PlannedEnd.Value;
+                    if (timeDelta < TimeSpan.Zero)
+                    {
+                        msg = $"Chillzóna je zkrácena do **{state.PlannedEnd.Value:HH:mm}** {PeepoSushiRoll}";
+                        if (state.NotePublic != null)
+                        {
+                            msg += " " + state.NotePublic;
+                        }
+                    }
+                    else if (timeDelta > TimeSpan.FromMinutes(15))
+                    {
+                        msg = $"Chillzóna je prodloužena do **{state.PlannedEnd.Value:HH:mm}** {Hypers}";
+                        if (state.NotePublic != null)
+                        {
+                            msg += " " + state.NotePublic;
+                        }
+                    }
+
+                    if (previousState.MadeById != state.MadeById
+                        && madeByName != null)
+                        msg += $" Nyní pro vás otevírá {madeByName} {PeepoLove}";
+                }
+                else
+                {
+                    var openTillString = $"**do {state.PlannedEnd.Value:HH:mm}**";
+                    var nextBarOpening = await _stateService.GetNextPlannedState(StateType.OpenBar);
+                    if (nextBarOpening != null &&
+                        nextBarOpening.Start - state.PlannedEnd.Value < TimeSpan.FromMinutes(15))
+                    {
+                        openTillString = $"až do otvíračky (v {nextBarOpening.Start:HH:mm})";
+                    }
+
+                    msg = $"Kachna je otevřena v režimu chillzóna {openTillString}! {Hypers}";
+                    if (madeByName != null)
+                    {
+                        msg += $" Otevírá pro vás {madeByName} {PeepoLove}";
+                    }
+
+                    if (state.NotePublic != null)
+                    {
+                        msg += " " + state.NotePublic;
+                    }
+                }
+            }
+            else if (state.Type == StateType.OpenBar &&
+                     (previousState is null || previousState.Type != StateType.OpenBar))
+            {
+                msg = "Máme tady otvíračku!";
+
+                if (state.PlannedEnd.HasValue)
+                {
+                    msg += $" Končíme ve {state.PlannedEnd.Value:HH:mm} {Hypers} {state.NotePublic}";
+                }
+            }
+
+            if (msg != null)
+            {
+                var result = await this.SendWebhookMessage(msg, true);
+                if (result != null)
+                {
+                    await this.SaveMessageId(stateId, result.Id);
+                }
+            }
         }
 
-        public Task PerformEndAction(int stateId, int? nextStateId)
+        private async Task SaveMessageId(int stateId, ulong messageId)
         {
-            throw new System.NotImplementedException();
+            var stateEntity = await _unitOfWork.PlannedStates.Get(stateId);
+            stateEntity.DiscordNotificationId = messageId;
+
+            try
+            {
+                await _unitOfWork.SaveChanges();
+            }
+            catch (Exception e)
+            {
+                _logger.LogError(e, "Cannot save Discord message ID.");
+            }
+        }
+
+        private async Task<ulong?> GetMessageId(int stateId)
+        {
+            var stateEntity = await _unitOfWork.PlannedStates.Get(stateId);
+            return stateEntity?.DiscordNotificationId;
+        }
+
+        public async Task PerformEndAction(int stateId, int? nextStateId)
+        {
+            var messageId = await this.GetMessageId(stateId);
+            if (messageId.HasValue)
+            {
+                await this.DeleteWebhookMessage(messageId.Value);
+            }
         }
     }
 }

--- a/KachnaOnline.Business/Services/StatePlanning/TransitionHandlers/SaveEndedDateTimeTransitionHandler.cs
+++ b/KachnaOnline.Business/Services/StatePlanning/TransitionHandlers/SaveEndedDateTimeTransitionHandler.cs
@@ -21,12 +21,12 @@ namespace KachnaOnline.Business.Services.StatePlanning.TransitionHandlers
             _unitOfWork = unitOfWork;
         }
 
-        public Task PerformStartAction(int stateId)
+        public Task PerformStartAction(int stateId, int? previousStateId)
         {
             return Task.CompletedTask;
         }
 
-        public async Task PerformEndAction(int stateId)
+        public async Task PerformEndAction(int stateId, int? nextStateId)
         {
             var state = await _unitOfWork.PlannedStates.Get(stateId);
             if (!state.Ended.HasValue)

--- a/KachnaOnline.Business/Services/StatePlanning/TransitionHandlers/SuDiscordTransitionHandler.cs
+++ b/KachnaOnline.Business/Services/StatePlanning/TransitionHandlers/SuDiscordTransitionHandler.cs
@@ -23,16 +23,14 @@ namespace KachnaOnline.Business.Services.StatePlanning.TransitionHandlers
             _stateService = stateService;
         }
 
-        public Task PerformStartAction(int stateId)
+        public Task PerformStartAction(int stateId, int? previousStateId)
         {
-            _logger.LogInformation("Discord TH start action for {Id}", stateId);
-            return Task.CompletedTask;
+            throw new System.NotImplementedException();
         }
 
-        public Task PerformEndAction(int stateId)
+        public Task PerformEndAction(int stateId, int? nextStateId)
         {
-            _logger.LogInformation("Discord TH end action for {Id}", stateId);
-            return Task.CompletedTask;
+            throw new System.NotImplementedException();
         }
     }
 }

--- a/KachnaOnline.Business/Services/StatePlanning/TransitionHandlers/SuDiscordTransitionHandler.cs
+++ b/KachnaOnline.Business/Services/StatePlanning/TransitionHandlers/SuDiscordTransitionHandler.cs
@@ -1,0 +1,38 @@
+﻿using System.Net.Http;
+using System.Threading.Tasks;
+using KachnaOnline.Business.Configuration;
+using KachnaOnline.Business.Services.Abstractions;
+using KachnaOnline.Business.Services.Discord;
+using KachnaOnline.Business.Services.StatePlanning.Abstractions;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
+
+namespace KachnaOnline.Business.Services.StatePlanning.TransitionHandlers
+{
+    public class SuDiscordTransitionHandler : DiscordWebhookClient, IStateTransitionHandler
+    {
+        private readonly ILogger<SuDiscordTransitionHandler> _logger;
+        private readonly IClubStateService _stateService;
+
+        public SuDiscordTransitionHandler(IOptionsMonitor<ClubStateOptions> options,
+            IHttpClientFactory httpClientFactory,
+            ILogger<SuDiscordTransitionHandler> logger, IClubStateService stateService)
+            : base(options.CurrentValue.SuDiscordWebhookUrl, httpClientFactory, logger)
+        {
+            _logger = logger;
+            _stateService = stateService;
+        }
+
+        public Task PerformStartAction(int stateId)
+        {
+            _logger.LogInformation("Discord TH start action for {Id}", stateId);
+            return Task.CompletedTask;
+        }
+
+        public Task PerformEndAction(int stateId)
+        {
+            _logger.LogInformation("Discord TH end action for {Id}", stateId);
+            return Task.CompletedTask;
+        }
+    }
+}

--- a/KachnaOnline.Business/Services/StatePlanning/TransitionHandlers/SuDiscordTransitionHandler.cs
+++ b/KachnaOnline.Business/Services/StatePlanning/TransitionHandlers/SuDiscordTransitionHandler.cs
@@ -1,4 +1,7 @@
-﻿using System;
+﻿// SuDiscordTransitionHandler.cs
+// Author: Ondřej Ondryáš
+
+using System;
 using System.Net.Http;
 using System.Threading.Tasks;
 using KachnaOnline.Business.Configuration;
@@ -35,7 +38,7 @@ namespace KachnaOnline.Business.Services.StatePlanning.TransitionHandlers
             var previousState = previousStateId.HasValue ? await _stateService.GetState(previousStateId.Value) : null;
 
             var madeBy = state.MadeById.HasValue ? await _userService.GetUser(state.MadeById.Value) : null;
-            var madeByName = madeBy.GetDiscordMention();
+            var madeByName = madeBy.GetDiscordMention(true);
 
             string msg = null;
 
@@ -71,6 +74,16 @@ namespace KachnaOnline.Business.Services.StatePlanning.TransitionHandlers
                 else
                 {
                     msg = $"Otevřeno od {state.Start:HH:mm} do {state.PlannedEnd.Value:HH:mm}. Otevírá {madeByName}.";
+
+                    if (state.NoteInternal != null)
+                    {
+                        msg += "\\nInterní poznámka: " + state.NoteInternal;
+                    }
+
+                    if (state.NotePublic != null)
+                    {
+                        msg += "\\nVeřejná poznámka: " + state.NotePublic;
+                    }
                 }
             }
             else if (state.Type == StateType.OpenBar && previousState?.Type == StateType.OpenChillzone)
@@ -80,16 +93,6 @@ namespace KachnaOnline.Business.Services.StatePlanning.TransitionHandlers
 
             if (msg != null)
             {
-                if (state.NoteInternal != null)
-                {
-                    msg += "\\nInterní poznámka: " + state.NoteInternal;
-                }
-
-                if (state.NotePublic != null)
-                {
-                    msg += "\\nVeřejná poznámka: " + state.NotePublic;
-                }
-
                 _logger.LogDebug("Sending chillzone start message to SU Discord server.");
                 await this.SendWebhookMessage(msg);
             }

--- a/KachnaOnline.Business/Services/StatePlanning/TransitionHandlers/SuDiscordTransitionHandler.cs
+++ b/KachnaOnline.Business/Services/StatePlanning/TransitionHandlers/SuDiscordTransitionHandler.cs
@@ -1,6 +1,9 @@
-﻿using System.Net.Http;
+﻿using System;
+using System.Net.Http;
 using System.Threading.Tasks;
 using KachnaOnline.Business.Configuration;
+using KachnaOnline.Business.Extensions;
+using KachnaOnline.Business.Models.ClubStates;
 using KachnaOnline.Business.Services.Abstractions;
 using KachnaOnline.Business.Services.Discord;
 using KachnaOnline.Business.Services.StatePlanning.Abstractions;
@@ -13,24 +16,93 @@ namespace KachnaOnline.Business.Services.StatePlanning.TransitionHandlers
     {
         private readonly ILogger<SuDiscordTransitionHandler> _logger;
         private readonly IClubStateService _stateService;
+        private readonly IUserService _userService;
 
         public SuDiscordTransitionHandler(IOptionsMonitor<ClubStateOptions> options,
             IHttpClientFactory httpClientFactory,
-            ILogger<SuDiscordTransitionHandler> logger, IClubStateService stateService)
+            ILogger<SuDiscordTransitionHandler> logger, IClubStateService stateService,
+            IUserService userService)
             : base(options.CurrentValue.SuDiscordWebhookUrl, httpClientFactory, logger)
         {
             _logger = logger;
             _stateService = stateService;
+            _userService = userService;
         }
 
-        public Task PerformStartAction(int stateId, int? previousStateId)
+        public async Task PerformStartAction(int stateId, int? previousStateId)
         {
-            throw new System.NotImplementedException();
+            var state = await _stateService.GetState(stateId);
+            var previousState = previousStateId.HasValue ? await _stateService.GetState(previousStateId.Value) : null;
+
+            var madeBy = state.MadeById.HasValue ? await _userService.GetUser(state.MadeById.Value) : null;
+            var madeByName = madeBy.GetDiscordMention();
+
+            string msg = null;
+
+            if (state.Type == StateType.OpenChillzone)
+            {
+                if (!state.PlannedEnd.HasValue)
+                {
+                    _logger.LogCritical("Data inconsistency: chillzone with no planned end (ID {Id}).", state.Id);
+                    return;
+                }
+
+                if (previousState?.Type == StateType.OpenChillzone)
+                {
+                    if (previousState.MadeById != state.MadeById)
+                    {
+                        msg = $"Předáno {madeByName} v {state.Start:HH:mm}. ";
+                    }
+
+                    if (previousState.PlannedEnd.HasValue)
+                    {
+                        var timeDelta = previousState.PlannedEnd.Value - state.PlannedEnd.Value;
+
+                        if (timeDelta > TimeSpan.Zero)
+                        {
+                            msg += $"Zkráceno do {state.PlannedEnd.Value:HH:mm}.";
+                        }
+                        else if (timeDelta < TimeSpan.Zero)
+                        {
+                            msg += $"Prodlouženo do {state.PlannedEnd.Value:HH:mm}.";
+                        }
+                    }
+                }
+                else
+                {
+                    msg = $"Otevřeno od {state.Start:HH:mm} do {state.PlannedEnd.Value:HH:mm}. Otevírá {madeByName}.";
+                }
+            }
+            else if (state.Type == StateType.OpenBar && previousState?.Type == StateType.OpenChillzone)
+            {
+                msg = "Ukončeno otvíračkou.";
+            }
+
+            if (msg != null)
+            {
+                if (state.NoteInternal != null)
+                {
+                    msg += "\\nInterní poznámka: " + state.NoteInternal;
+                }
+
+                if (state.NotePublic != null)
+                {
+                    msg += "\\nVeřejná poznámka: " + state.NotePublic;
+                }
+
+                _logger.LogDebug("Sending chillzone start message to SU Discord server.");
+                await this.SendWebhookMessage(msg);
+            }
         }
 
-        public Task PerformEndAction(int stateId, int? nextStateId)
+        public async Task PerformEndAction(int stateId, int? nextStateId)
         {
-            throw new System.NotImplementedException();
+            var state = await _stateService.GetState(stateId);
+            if (state.Type == StateType.OpenChillzone && !nextStateId.HasValue)
+            {
+                _logger.LogDebug("Sending chillzone end message to SU Discord server.");
+                await this.SendWebhookMessage($"Zavřeno v {DateTime.Now:HH:mm}.");
+            }
         }
     }
 }

--- a/KachnaOnline.Data/Entities/ClubStates/PlannedState.cs
+++ b/KachnaOnline.Data/Entities/ClubStates/PlannedState.cs
@@ -25,6 +25,8 @@ namespace KachnaOnline.Data.Entities.ClubStates
         public int? RepeatingStateId { get; set; }
         public int? AssociatedEventId { get; set; }
 
+        public ulong? DiscordNotificationId { get; set; }
+
         // Navigation properties
         public virtual PlannedState NextPlannedState { get; set; }
         public virtual RepeatingState RepeatingState { get; set; }

--- a/KachnaOnline.Data/Migrations/20211126220341_StateMessageDiscordId.Designer.cs
+++ b/KachnaOnline.Data/Migrations/20211126220341_StateMessageDiscordId.Designer.cs
@@ -3,6 +3,7 @@ using System;
 using KachnaOnline.Data;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 
@@ -11,9 +12,10 @@ using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 namespace KachnaOnline.Data.Migrations
 {
     [DbContext(typeof(AppDbContext))]
-    partial class AppDbContextModelSnapshot : ModelSnapshot
+    [Migration("20211126220341_StateMessageDiscordId")]
+    partial class StateMessageDiscordId
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/KachnaOnline.Data/Migrations/20211126220341_StateMessageDiscordId.cs
+++ b/KachnaOnline.Data/Migrations/20211126220341_StateMessageDiscordId.cs
@@ -1,0 +1,25 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace KachnaOnline.Data.Migrations
+{
+    public partial class StateMessageDiscordId : Migration
+    {
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AddColumn<decimal>(
+                name: "DiscordNotificationId",
+                table: "PlannedStates",
+                type: "numeric(20,0)",
+                nullable: true);
+        }
+
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropColumn(
+                name: "DiscordNotificationId",
+                table: "PlannedStates");
+        }
+    }
+}

--- a/KachnaOnline.sln.DotSettings
+++ b/KachnaOnline.sln.DotSettings
@@ -26,4 +26,5 @@
 	<s:Boolean x:Key="/Default/Environment/SettingsMigration/IsMigratorApplied/=JetBrains_002EReSharper_002EPsi_002ECSharp_002ECodeStyle_002ESettingsUpgrade_002EMigrateBlankLinesAroundFieldToBlankLinesAroundProperty/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=Chillzone/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=Dtos/@EntryIndexedValue">True</s:Boolean>
+	<s:Boolean x:Key="/Default/UserDictionary/Words/=Fitwide/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=Kachna/@EntryIndexedValue">True</s:Boolean></wpf:ResourceDictionary>

--- a/publish.sh
+++ b/publish.sh
@@ -1,0 +1,4 @@
+#!/bin/sh
+
+mkdir -p Publish
+dotnet publish KachnaOnline.App -c Release -o Publish/ --self-contained false -r linux-x64


### PR DESCRIPTION
This PR:

- Separates webhook logic from `DiscordBoardGamesNotificationHandler` into an abstract `DiscordWebhookClient`
- Adds Discord notifications about state changes (in `FitwideDiscordTransitionHandler` and `SuDiscordTransitionHandler`)
    - Adds a nullable `DiscordNotificationId` attribute to `PlannedState` (running **migrations** is required)
- Fixes a few bugs in `ClubStateService`
- Enables unauthenticated SMTP connections (this is needed in production)
- Moves `--migrate-db` and `--bootstrap-db` to Main
    - This is needed because both our background services would run before the migrations and thus throw an exception
- Adds a simple publishing script