### PR TITLE
Navigation bar improvements

### DIFF
--- a/ClientApp/KachnaOnline/src/app/app-routing.module.ts
+++ b/ClientApp/KachnaOnline/src/app/app-routing.module.ts
@@ -12,9 +12,8 @@ const routes: Routes = [
 The order of routes is important because the Router uses a first-match wins strategy when matching routes, so more specific routes should be placed above less specific routes. List routes with a static path first, followed by an empty path route, which matches the default route. The wildcard route comes last because it matches every URL and the Router selects it only if no other routes match first.
 */
   {path: 'forbidden', component: ForbiddenComponent},
-
+  {path: 'home', redirectTo: '', pathMatch: 'full'}, // Redirect from '/home' to default home page.
   {path: '', component: HomeComponent}, // Default home page.
-  //{ path: '',   redirectTo: '/states', pathMatch: 'full' }, // Redirect to default states page.
   {path: '**', component: PageNotFoundComponent},  // Wildcard route for a 404 page.
 ];
 

--- a/ClientApp/KachnaOnline/src/app/navigation-bar/navigation-bar.component.html
+++ b/ClientApp/KachnaOnline/src/app/navigation-bar/navigation-bar.component.html
@@ -25,23 +25,31 @@ Author: David Chocholatý
     <app-account-popup class="d-lg-none d-xl-none"></app-account-popup>
 
     <div id="collapse_navbar" [ngbCollapse]="isMenuCollapsed" class="collapse navbar-collapse">
-      <ul class="navbar-nav mr-auto">
-        <li class="nav-item mr-3" ngbDropdown *ngIf="authenticationService.isStatesManager()">
+      <ul class="navbar-nav">
+        <li class="nav-item align-self-xl-center align-self-lg-center mr-xl-3 mr-lg-3 mt-xl-0 mt-lg-0 mt-3" ngbDropdown
+            *ngIf="authenticationService.isStatesManager()">
           <div class="btn-group btn-block mr-3">
-            <button type="button" class="btn btn-secondary text-nowrap btn-block" style="text-align:left"
-                    [routerLink]="'.'" (click)="isMenuCollapsed = true">Stav klubu
+            <button type="button" class="btn btn-secondary text-nowrap btn-block
+             d-xl-block d-lg-block d-md-block d-sm-block align-self-md-center d-none" style="text-align:left"
+                    routerLink="" (click)="isMenuCollapsed = true">Stav klubu
             </button>
-            <button type="button" class="btn btn-secondary dropdown-toggle dropdown-toggle-split dropdown-menu-right"
+            <button type="button" class="btn btn-secondary dropdown-toggle dropdown-toggle-split dropdown-menu-right
+            d-xl-block d-lg-block d-md-block d-sm-block d-none"
                     id="tmp" ngbDropdownToggle data-toggle="dropdown" aria-haspopup="true" aria-expanded="false"
                     data-reference="parent">
               <span class="sr-only">Toggle Dropdown</span>
             </button>
+            <button class="btn btn-secondary text-nowrap btn-block d-xl-none d-lg-none d-md-none d-sm-none" style="text-align:left"
+                    ngbDropdownToggle>Stav klubu</button>
             <div class="dropdown-menu dropdown-menu-text dropdown-menu-right" aria-labelledby="tmp" ngbDropdownMenu>
-              <button (click)="isMenuCollapsed = true" class="dropdown-item" routerLink="/states/change"
+              <button class="dropdown-item d-lg-none d-xl-none d-md-none d-sm-none" (click)="isMenuCollapsed = true"
+                      routerLink="" ngbDropdownItem>Aktuální stav klubu
+              </button>
+              <button (click)="isMenuCollapsed = true" class="dropdown-item" routerLink="/states/change" routerLinkActive="active"
                       ngbDropdownItem>
                 Změnit aktuální stav
               </button>
-              <button (click)="isMenuCollapsed = true" class="dropdown-item" routerLink="/states/plan" ngbDropdownItem>
+              <button (click)="isMenuCollapsed = true" class="dropdown-item" routerLink="/states/plan" routerLinkActive="active" ngbDropdownItem>
                 Naplánovat budoucí stav
               </button>
               <button (click)="isMenuCollapsed = true" class="dropdown-item" href="#" ngbDropdownItem>Plán stavů
@@ -56,16 +64,18 @@ Author: David Chocholatý
           </div>
         </li>
 
-        <li class="nav-item mr-3" ngbDropdown>
+        <li class="nav-item align-self-xl-center align-self-lg-center mr-xl-3 mr-lg-3 mt-xl-0 mt-lg-0 mt-3" ngbDropdown>
           <div class="btn-group mr-3 btn-block">
-            <button type="button" class="btn btn-secondary text-nowrap btn-block" style="text-align:left"
+            <button type="button" class="btn btn-secondary text-nowrap btn-block d-xl-block d-lg-block d-md-block d-sm-block d-none" style="text-align:left"
                     routerLink="events/current" routerLinkActive="active" (click)="isMenuCollapsed = true">Akce
             </button>
-            <button type="button" class="btn btn-secondary dropdown-toggle dropdown-toggle-split dropdown-menu-right"
+            <button type="button" class="btn btn-secondary dropdown-toggle dropdown-toggle-split dropdown-menu-right d-lg-block d-md-block d-sm-block d-none"
                     ngbDropdownToggle data-toggle="dropdown" aria-haspopup="true" aria-expanded="false"
                     data-reference="parent">
               <span class="sr-only">Toggle Dropdown</span>
             </button>
+            <button class="btn btn-secondary text-nowrap btn-block d-xl-none d-lg-none d-md-none d-sm-none" style="text-align:left"
+                    ngbDropdownToggle>Akce</button>
             <div class="dropdown-menu dropdown-menu-text dropdown-menu-right" aria-labelledby="tmp" ngbDropdownMenu>
               <button (click)="isMenuCollapsed = true" class="dropdown-item" routerLink="events/current"
                       routerLinkActive="active" ngbDropdownItem>Probíhající akce
@@ -88,18 +98,23 @@ Author: David Chocholatý
           </div>
         </li>
 
-        <li class="nav-item mr-3" ngbDropdown>
+        <li class="nav-item align-self-xl-center align-self-lg-center mr-xl-3 mr-lg-3 mt-xl-0 mt-lg-0 mt-3" ngbDropdown>
           <div class="btn-group mr-3 btn-block">
-            <button type="button" class="btn btn-secondary text-nowrap btn-block" style="text-align:left"
+            <button type="button" class="btn btn-secondary text-nowrap btn-block d-xl-block d-lg-block d-md-block d-sm-block d-none" style="text-align:left"
                     routerLink="board-games" (click)="isMenuCollapsed = true">Deskovky
             </button>
             <button *ngIf="authenticationService.isLoggedIn()" type="button"
-                    class="btn btn-secondary dropdown-toggle dropdown-toggle-split dropdown-menu-right"
+                    class="btn btn-secondary dropdown-toggle dropdown-toggle-split dropdown-menu-right d-xl-block d-lg-block d-md-block d-sm-block d-none"
                     ngbDropdownToggle data-toggle="dropdown" aria-haspopup="true" aria-expanded="false"
                     data-reference="parent">
               <span class="sr-only">Toggle Dropdown</span>
             </button>
+            <button class="btn btn-secondary text-nowrap btn-block d-xl-none d-lg-none d-md-none d-sm-none" style="text-align:left"
+                    ngbDropdownToggle>Deskovky</button>
             <div class="dropdown-menu dropdown-menu-text dropdown-menu-right" aria-labelledby="tmp" ngbDropdownMenu>
+              <button class="dropdown-item d-lg-none d-xl-none d-md-none d-sm-none" (click)="isMenuCollapsed = true"
+                      routerLink="board-games" routerLinkActive="active" ngbDropdownItem>Přehled deskových her
+              </button>
               <button class="dropdown-item" routerLink="board-games/reservations" routerLinkActive="active"
                       (click)="isMenuCollapsed = true" *ngIf="authenticationService.isLoggedIn()" ngbDropdownItem>Moje
                 rezervace
@@ -123,23 +138,27 @@ Author: David Chocholatý
           </div>
         </li>
 
-        <li class="nav-item mr-3" ngbDropdown *ngIf="authenticationService.isAdmin()">
+        <li class="nav-item align-self-xl-center align-self-lg-center mr-xl-3 mr-lg-3 mt-xl-0 mt-lg-0 mt-3" ngbDropdown *ngIf="authenticationService.isAdmin()">
           <div class="btn-group mr-3 btn-block">
-            <button type="button" class="btn btn-secondary text-nowrap btn-block" style="text-align:left"
-                    routerLink="users" *ngIf="authenticationService.isAdmin()" (click)="isMenuCollapsed = true">
+            <button type="button" class="btn btn-secondary text-nowrap btn-block d-xl-block d-lg-block d-md-block d-sm-block d-none" style="text-align:left"
+                    routerLink="users" routerLinkActive="active" (click)="isMenuCollapsed = true">
               Uživatelé
             </button>
-            <button type="button" class="btn btn-secondary dropdown-toggle dropdown-toggle-split dropdown-menu-right"
+            <button type="button" class="btn btn-secondary dropdown-toggle dropdown-toggle-split dropdown-menu-right d-xl-block d-lg-block d-md-block d-sm-block d-none"
                     ngbDropdownToggle data-toggle="dropdown" aria-haspopup="true" aria-expanded="false"
                     data-reference="parent">
               <span class="sr-only">Toggle Dropdown</span>
             </button>
+            <button class="btn btn-secondary text-nowrap btn-block d-xl-none d-lg-none d-md-none d-sm-none" style="text-align:left"
+                    ngbDropdownToggle>Uživatelé</button>
             <div class="dropdown-menu dropdown-menu-text dropdown-menu-right" aria-labelledby="tmp" ngbDropdownMenu>
-              <button class="dropdown-item" (click)="isMenuCollapsed = true" href="#"
-                      *ngIf="authenticationService.isAdmin()" ngbDropdownItem>...
+              <button ngbDropdownItem (click)="isMenuCollapsed = true">...
+              </button>
+              <button class="dropdown-item d-lg-none d-xl-none d-md-none d-sm-none" (click)="isMenuCollapsed = true"
+                      routerLink="users" routerLinkActive="active" ngbDropdownItem>Seznam uživatelů
               </button>
               <div class="dropdown-divider"></div>
-              <button ngbDropdownItem (click)="isMenuCollapsed = true" *ngIf="authenticationService.isAdmin()">...
+              <button ngbDropdownItem (click)="isMenuCollapsed = true">...
               </button>
             </div>
           </div>

--- a/ClientApp/KachnaOnline/src/app/navigation-bar/navigation-bar.component.html
+++ b/ClientApp/KachnaOnline/src/app/navigation-bar/navigation-bar.component.html
@@ -99,11 +99,14 @@ Author: David Chocholatý
         </li>
 
         <li class="nav-item align-self-xl-center align-self-lg-center mr-xl-3 mr-lg-3 mt-xl-0 mt-lg-0 mt-3" ngbDropdown>
-          <div class="btn-group mr-3 btn-block">
+          <button type="button" *ngIf="authenticationService.isLoggedOut()" class="btn btn-secondary text-nowrap btn-block d-xl-block d-lg-block d-md-block d-sm-block d-none" style="text-align:left"
+                  routerLink="board-games" (click)="isMenuCollapsed = true">Deskovky
+          </button>
+          <div class="btn-group mr-3 btn-block" *ngIf="authenticationService.isLoggedIn()">
             <button type="button" class="btn btn-secondary text-nowrap btn-block d-xl-block d-lg-block d-md-block d-sm-block d-none" style="text-align:left"
                     routerLink="board-games" (click)="isMenuCollapsed = true">Deskovky
             </button>
-            <button *ngIf="authenticationService.isLoggedIn()" type="button"
+            <button type="button"
                     class="btn btn-secondary dropdown-toggle dropdown-toggle-split dropdown-menu-right d-xl-block d-lg-block d-md-block d-sm-block d-none"
                     ngbDropdownToggle data-toggle="dropdown" aria-haspopup="true" aria-expanded="false"
                     data-reference="parent">

--- a/ClientApp/KachnaOnline/src/app/navigation-bar/navigation-bar.component.html
+++ b/ClientApp/KachnaOnline/src/app/navigation-bar/navigation-bar.component.html
@@ -15,12 +15,13 @@ Author: David Chocholatý
       <a class="navbar-brand" routerLink="" (click)="isMenuCollapsed = true">
         <img class="image" style="cursor: pointer;" width="40" routerLink="" (click)="isMenuCollapsed = true"
              alt="Kachna Online Logo"
-             src="assets/kachna_bez_peny.png"/>
+             src="assets/kachna_bez_peny.png" />
         Kachna Online
       </a>
+
+      <app-loading-spinner class="d-lg-none d-xl-none text-light"></app-loading-spinner>
     </div>
 
-    <app-loading-spinner class="d-lg-none d-xl-none mr-2 text-light"></app-loading-spinner>
     <app-account-popup class="d-lg-none d-xl-none"></app-account-popup>
 
     <div id="collapse_navbar" [ngbCollapse]="isMenuCollapsed" class="collapse navbar-collapse">

--- a/ClientApp/KachnaOnline/src/app/navigation-bar/navigation-bar.component.ts
+++ b/ClientApp/KachnaOnline/src/app/navigation-bar/navigation-bar.component.ts
@@ -21,7 +21,7 @@ export class NavigationBarComponent implements OnInit {
     public boardGamesService: BoardGamesService,
     public stateService: StatesService,
     public router: Router,
-    public storeService: BoardGamesStoreService
+    public storeService: BoardGamesStoreService,
   ) {}
 
   public isMenuCollapsed = true;


### PR DESCRIPTION
This PR improves navigation bar with several changes such as:
- moving Kachna Online logo to the centre again (the logo have been shifted slightly to the left by the loading spinner taking a place in the row as an invisible item),
- showing only dropdowns in hamburger menu for mobile devices instead of small split-dropdown buttons,
- add buttons to dropdown collapse for missing clickable main part of split-dropdown buttons when the split-dropdown buttons are replaced by the normal dropdown buttons for mobile devices and
- add margin between buttons in hamburger menu.