### PR TITLE
Fixed aspect ratio for board game images

### DIFF
--- a/ClientApp/KachnaOnline/src/app/board-games/board-game-details/board-game-details.component.css
+++ b/ClientApp/KachnaOnline/src/app/board-games/board-game-details/board-game-details.component.css
@@ -1,0 +1,4 @@
+.img-fluid{
+  object-fit: contain;
+  aspect-ratio: 1 / 1;
+}

--- a/ClientApp/KachnaOnline/src/app/board-games/board-games-page/board-game-card/board-game-card.component.css
+++ b/ClientApp/KachnaOnline/src/app/board-games/board-games-page/board-game-card/board-game-card.component.css
@@ -1,0 +1,4 @@
+.card-img-top{
+  object-fit: contain;
+  aspect-ratio: 1 / 1;
+}


### PR DESCRIPTION
I've made a simple CSS change for board game images (both grid and detail view) that allows the usage of non-square images.

This is done by using two CSS properties on the image itself:
* [object-fit](https://developer.mozilla.org/en-US/docs/Web/CSS/object-fit) to resize the image to element while respecting its original aspect ratio 
* [aspect-ratio](https://developer.mozilla.org/en-US/docs/Web/CSS/aspect-ratio) to make the DOM element square

### Here is the fix in action (with random portrait image)
![image](https://user-images.githubusercontent.com/7803688/155209901-36c83c7b-bd32-4fd9-b949-17b8c8b4e310.png)