### PR TITLE
Add year selector for events overview

### DIFF
--- a/ClientApp/KachnaOnline/src/app/events/events-list/events-list.component.html
+++ b/ClientApp/KachnaOnline/src/app/events/events-list/events-list.component.html
@@ -5,6 +5,9 @@ Author: David Chocholatý
 
 <h1>Přehled akcí</h1>
 
+<app-year-selection (yearChange)="this.yearChanged($event)"
+                     [justifyCenter]="false"></app-year-selection>
+
 <div class="d-flex align-items-center">
   <span class="dot bg-secondary"></span>
   <span class="mr-4">Proběhlé akce</span>

--- a/ClientApp/KachnaOnline/src/app/events/events-list/events-list.component.ts
+++ b/ClientApp/KachnaOnline/src/app/events/events-list/events-list.component.ts
@@ -8,7 +8,6 @@ import { ToastrService } from "ngx-toastr";
 import { Router } from "@angular/router";
 import { AuthenticationService } from "../../shared/services/authentication.service";
 import { NgbModal } from "@ng-bootstrap/ng-bootstrap";
-import { first } from "rxjs/operators";
 import { throwError } from "rxjs";
 
 @Component({
@@ -30,16 +29,12 @@ export class EventsListComponent implements OnInit {
   ) { }
 
   ngOnInit(): void {
-    let firstDayOfYear = new Date(this.now.getFullYear(), 0, 1, 0, 0, 0, 0);
-    let lastDayOfYear = new Date(firstDayOfYear);
-    lastDayOfYear.setFullYear(lastDayOfYear.getFullYear() + 1);
-    this.eventsService.getBetween(firstDayOfYear, lastDayOfYear).toPromise()
-      .then((res: Event[]) => {
-        this.events = res.sort((a, b) => a.from.getTime() - b.from.getTime());
-      }).catch(err => {
+    this.eventsService.getYearEvents(this.now).subscribe(
+      res => this.setEvents(res),
+      err => {
         this.toastrService.error("Stažení akcí selhalo.", "Stažení akcí");
         return throwError(err);
-    });
+      });
   }
 
   openEventDetail(eventDetail: Event) {
@@ -52,5 +47,22 @@ export class EventsListComponent implements OnInit {
 
   onModifyButtonClicked(selectedEventDetail: Event) {
     this.router.navigate([`/events/${selectedEventDetail.id}/edit`]).then();
+  }
+
+  yearChanged(year: Date) {
+    this.eventsService.getYearEvents(year).subscribe(
+      res => this.setEvents(res),
+      err => {
+        this.toastrService.error("Stažení akcí selhalo.", "Stažení akcí");
+        return throwError(err);
+      });
+  }
+
+  setEvents(eventModels: Event[]): void {
+    this.events = this.sortEvents(eventModels);
+  }
+
+  sortEvents(events: Event[]): Event[] {
+    return events.sort((a, b) => a.from.getTime() - b.from.getTime());
   }
 }

--- a/ClientApp/KachnaOnline/src/app/shared/components/components.module.ts
+++ b/ClientApp/KachnaOnline/src/app/shared/components/components.module.ts
@@ -14,6 +14,7 @@ import { FormsModule } from "@angular/forms";
 import { MonthSelectionComponent } from './month-selection/month-selection.component';
 import { PipesModule } from "../pipes/pipes.module";
 import { DeletionConfirmationModalComponent } from './deletion-confirmation-modal/deletion-confirmation-modal.component';
+import { YearSelectionComponent } from "./year-selection/year-selection.component";
 
 
 @NgModule({
@@ -23,6 +24,7 @@ import { DeletionConfirmationModalComponent } from './deletion-confirmation-moda
     NumberSelectionComponent,
     UserSearchComponent,
     MonthSelectionComponent,
+    YearSelectionComponent,
     DeletionConfirmationModalComponent,
   ],
   imports: [
@@ -38,6 +40,7 @@ import { DeletionConfirmationModalComponent } from './deletion-confirmation-moda
         ToggleableButtonComponent,
         NumberSelectionComponent,
         UserSearchComponent,
+        YearSelectionComponent,
         MonthSelectionComponent,
     ]
 })

--- a/ClientApp/KachnaOnline/src/app/shared/components/year-selection/year-selection.component.html
+++ b/ClientApp/KachnaOnline/src/app/shared/components/year-selection/year-selection.component.html
@@ -1,0 +1,17 @@
+<div class="d-flex {{justifyCenter ? 'justify-content-center' : ''}} mb-2">
+  <div>
+    <button class="btn btn-sm btn-primary float-right" (click)="changeYear(-1)"
+            ><i class="fas fa-caret-left"></i>
+    </button>
+  </div>
+
+  <div class="text-center" style="width: 15em;">
+    <span class="d-inline-block h4 pl-3 pr-3 mb-0">
+      {{year.getFullYear()}}
+    </span>
+  </div>
+
+  <div>
+    <button class="btn btn-sm btn-primary" (click)="changeYear(1)"><i class="fas fa-caret-right"></i></button>
+  </div>
+</div>

--- a/ClientApp/KachnaOnline/src/app/shared/components/year-selection/year-selection.component.ts
+++ b/ClientApp/KachnaOnline/src/app/shared/components/year-selection/year-selection.component.ts
@@ -1,0 +1,24 @@
+import { Component, Output, OnInit, EventEmitter, Input } from '@angular/core';
+
+@Component({
+  selector: 'app-year-selection',
+  templateUrl: './year-selection.component.html',
+})
+export class YearSelectionComponent implements OnInit {
+  @Input() public justifyCenter: boolean = true;
+  @Output() public yearChange: EventEmitter<Date> = new EventEmitter()
+
+  year: Date;
+
+  constructor() {
+  }
+
+  ngOnInit(): void {
+    this.year = new Date();
+  }
+
+  changeYear(delta: number) {
+    this.year.setFullYear(this.year.getFullYear() + delta);
+    this.yearChange.emit(this.year);
+  }
+}

--- a/ClientApp/KachnaOnline/src/app/shared/services/events.service.ts
+++ b/ClientApp/KachnaOnline/src/app/shared/services/events.service.ts
@@ -77,6 +77,13 @@ export class EventsService {
     return this.getBetween(firstDay, lastDay);
   }
 
+  getYearEvents(year: Date) {
+    let firstDayOfYear = new Date(year.getFullYear(), 0, 1, 0, 0, 0, 0);
+    let lastDayOfYear = new Date(year.getFullYear(), 11, 31, 23, 59, 59);
+
+    return this.getBetween(firstDayOfYear, lastDayOfYear);
+  }
+
   getBetween(start: Date, end: Date): Observable<Event[]> {
     return this.getEventsInInterval(start.toISOString(), end.toISOString());
   }


### PR DESCRIPTION
This PR adds a year selector for events overview page to show events for the selected year. This allows to show events held in other than the current year, which was the previous behaviour.

In comparison with next events page, viewing past events (even from past years) is allowed here as this page serves as an overview of all events, not just a quick preview of next events.

Fixes #88.